### PR TITLE
Refactor neighbor storage for faster rebuilds

### DIFF
--- a/cpp/include/components.h
+++ b/cpp/include/components.h
@@ -21,15 +21,59 @@ public:
     int n;
     std::vector<double> box;
     double length;
-    std::vector<vec> center;
-    std::vector<vec> direction;
-    std::vector<vec> left_end;
-    std::vector<vec> right_end;
-    std::vector<vec> force;
-    std::vector<vec> torque;
-    std::vector<vec> velocity;
+
+    // Structure-of-arrays storage for vector quantities
+    std::vector<double> center_x, center_y, center_z;
+    std::vector<double> direction_x, direction_y, direction_z;
+    std::vector<double> left_end_x, left_end_y, left_end_z;
+    std::vector<double> right_end_x, right_end_y, right_end_z;
+    std::vector<double> force_x, force_y, force_z;
+    std::vector<double> torque_x, torque_y, torque_z;
+    std::vector<double> velocity_x, velocity_y, velocity_z;
     std::vector<double> f_load;
     std::vector<double> cb_strength;
+
+    struct VecRef {
+        double &x, &y, &z;
+        operator vec() const { return {x, y, z}; }
+        VecRef& operator=(const vec& v) { x = v.x; y = v.y; z = v.z; return *this; }
+        VecRef& operator+=(const vec& v) { x += v.x; y += v.y; z += v.z; return *this; }
+        VecRef& operator-=(const vec& v) { x -= v.x; y -= v.y; z -= v.z; return *this; }
+        VecRef& operator*=(double s) { x *= s; y *= s; z *= s; return *this; }
+        vec operator-(const VecRef& other) const { return {x - other.x, y - other.y, z - other.z}; }
+        vec operator+(const VecRef& other) const { return {x + other.x, y + other.y, z + other.z}; }
+        vec operator*(double s) const { return {x * s, y * s, z * s}; }
+        friend vec operator*(double s, const VecRef& v) { return {v.x * s, v.y * s, v.z * s}; }
+        vec operator/(double s) const { return {x / s, y / s, z / s}; }
+        void normalize() {
+            double norm = std::sqrt(x * x + y * y + z * z);
+            if (norm > 0) { x /= norm; y /= norm; z /= norm; }
+        }
+        double dot(const VecRef& other) const {
+            return x * other.x + y * other.y + z * other.z;
+        }
+        double norm() const { return std::sqrt(x * x + y * y + z * z); }
+    };
+
+    class VecArray {
+        std::vector<double>* x; std::vector<double>* y; std::vector<double>* z;
+    public:
+        VecArray(std::vector<double>& x_, std::vector<double>& y_, std::vector<double>& z_)
+            : x(&x_), y(&y_), z(&z_) {}
+        VecRef operator[](size_t i) { return VecRef{(*x)[i], (*y)[i], (*z)[i]}; }
+        const VecRef operator[](size_t i) const {
+            return VecRef{const_cast<double&>((*x)[i]), const_cast<double&>((*y)[i]), const_cast<double&>((*z)[i])};
+        }
+        size_t size() const { return x->size(); }
+    };
+
+    VecArray center;
+    VecArray direction;
+    VecArray left_end;
+    VecArray right_end;
+    VecArray force;
+    VecArray torque;
+    VecArray velocity;
 
     // Dictionary to store 1D features.
     std::unordered_map<std::string, std::vector<double>> custom_features;
@@ -52,6 +96,9 @@ public:
     // Operator overload for easy access to 1D features.
     std::vector<double>& operator[](const std::string& name);
 };
+
+// Helper to reduce temporary arrays into VecArray targets
+void reduce_array(std::vector<std::vector<vec>>& temp_array, Filament::VecArray& target_array);
 
 class Myosin : public Filament {
 public:

--- a/cpp/include/h5_utils.h
+++ b/cpp/include/h5_utils.h
@@ -21,8 +21,8 @@ using vec = utils::vec;
 std::vector<std::vector<int>> serializeActinIndicesPerActin(
     utils::MoleculeConnection& actinIndicesPerActin, int n_actins, int& max_bonds);
 
-// Flatten a vector of 2D points (vec) into a 1D array of doubles.
-std::vector<double> flatten_3d_array(std::vector<vec> array);
+// Flatten a vector-like structure into a 1D array of doubles.
+std::vector<double> flatten_3d_array(const Filament::VecArray& array);
 std::vector<double> flatten_2d_array(std::vector<std::vector<double>> array);
 
 // Create an empty (extendable) dataset within the specified group of the file.

--- a/cpp/include/neighborlist.h
+++ b/cpp/include/neighborlist.h
@@ -29,13 +29,15 @@ public:
     NeighborList();
 
     // Initialize the neighbor list with positions for actin and myosin.
-    void initialize(const std::vector<vec>& actin_positions, const std::vector<vec>& myosin_positions);
+    void initialize(const std::vector<double>& actin_x, const std::vector<double>& actin_y, const std::vector<double>& actin_z,
+                    const std::vector<double>& myosin_x, const std::vector<double>& myosin_y, const std::vector<double>& myosin_z);
 
     // Rebuild the neighbor list using a cell list approach.
     void rebuild_neighbor_list();
 
     // Set current positions for each species.
-    void set_species_positions(const std::vector<vec>& actin_positions, const std::vector<vec>& myosin_positions);
+    void set_species_positions(const std::vector<double>& actin_x, const std::vector<double>& actin_y, const std::vector<double>& actin_z,
+                               const std::vector<double>& myosin_x, const std::vector<double>& myosin_y, const std::vector<double>& myosin_z);
 
     // Check if the neighbor list needs to be rebuilt (based on displacement).
     bool needs_rebuild() const;
@@ -66,8 +68,9 @@ public:
 
 private:
     // Helper functions.
-    std::tuple<int, int, int> get_cell_index(const vec& position) const;
-    double displacement(const vec& current, const vec& last) const;
+    std::tuple<int, int, int> get_cell_index(double x, double y, double z) const;
+    double displacement(double cx, double cy, double cz,
+                        double lx, double ly, double lz) const;
     void concatenate_positions();
     void track_species_types();
     // Data members.
@@ -78,13 +81,14 @@ private:
     double cell_size_x_, cell_size_y_, cell_size_z_;
     std::vector<std::tuple<int, int, int>> neighboring_cells;
 
-    std::vector<vec> actin_positions_;
-    std::vector<vec> myosin_positions_;
+    // Structure-of-arrays storage for positions.
+    std::vector<double> actin_x_, actin_y_, actin_z_;
+    std::vector<double> myosin_x_, myosin_y_, myosin_z_;
     size_t n_actins_;
-    std::vector<vec> last_actin_positions_;
-    std::vector<vec> last_myosin_positions_;
+    std::vector<double> last_actin_x_, last_actin_y_, last_actin_z_;
+    std::vector<double> last_myosin_x_, last_myosin_y_, last_myosin_z_;
 
-    std::vector<vec> all_positions_;
+    std::vector<double> all_x_, all_y_, all_z_;
     std::vector<ParticleType> species_types_;
     std::vector<std::vector<std::pair<int, ParticleType>>> neighbor_list_;
 

--- a/cpp/src/components.cpp
+++ b/cpp/src/components.cpp
@@ -5,42 +5,70 @@
 #include <cassert>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
+#include <omp.h>
 
 //===================
 // Filament Methods
 //===================
 
 // Default constructor.
-Filament::Filament() : n(0), length(0) {
-    // Optionally initialize other members if needed.
-}
+Filament::Filament()
+    : n(0), length(0),
+      center(center_x, center_y, center_z),
+      direction(direction_x, direction_y, direction_z),
+      left_end(left_end_x, left_end_y, left_end_z),
+      right_end(right_end_x, right_end_y, right_end_z),
+      force(force_x, force_y, force_z),
+      torque(torque_x, torque_y, torque_z),
+      velocity(velocity_x, velocity_y, velocity_z) {}
 
 // Parameterized constructor.
 Filament::Filament(int n0, double length0, std::vector<double> box0, gsl_rng* rng)
-    : n(n0), length(length0), box(box0)
+    : n(n0), box(box0), length(length0),
+      center(center_x, center_y, center_z),
+      direction(direction_x, direction_y, direction_z),
+      left_end(left_end_x, left_end_y, left_end_z),
+      right_end(right_end_x, right_end_y, right_end_z),
+      force(force_x, force_y, force_z),
+      torque(torque_x, torque_y, torque_z),
+      velocity(velocity_x, velocity_y, velocity_z)
 {
-    center.resize(n);
-    direction.resize(n);
-    left_end.resize(n);
-    right_end.resize(n);
-    force.resize(n);
-    torque.resize(n);
-    velocity.resize(n);
+    center_x.resize(n);
+    center_y.resize(n);
+    center_z.resize(n);
+    direction_x.resize(n);
+    direction_y.resize(n);
+    direction_z.resize(n);
+    left_end_x.resize(n);
+    left_end_y.resize(n);
+    left_end_z.resize(n);
+    right_end_x.resize(n);
+    right_end_y.resize(n);
+    right_end_z.resize(n);
+    force_x.resize(n);
+    force_y.resize(n);
+    force_z.resize(n);
+    torque_x.resize(n);
+    torque_y.resize(n);
+    torque_z.resize(n);
+    velocity_x.resize(n);
+    velocity_y.resize(n);
+    velocity_z.resize(n);
     f_load.resize(n);
     cb_strength.resize(n);
-    
-    // Randomly initialize the center positions and theta values.
+
+    // Randomly initialize the center positions and directions.
     for (int i = 0; i < n; i++) {
-        center[i].x = gsl_ran_flat(rng, -0.5 * box[0], 0.5 * box[0]);
-        center[i].y = gsl_ran_flat(rng, -0.5 * box[1], 0.5 * box[1]);
-        center[i].z = gsl_ran_flat(rng, -0.5 * box[2], 0.5 * box[2]);
+        center_x[i] = gsl_ran_flat(rng, -0.5 * box[0], 0.5 * box[0]);
+        center_y[i] = gsl_ran_flat(rng, -0.5 * box[1], 0.5 * box[1]);
+        center_z[i] = gsl_ran_flat(rng, -0.5 * box[2], 0.5 * box[2]);
         double x = gsl_ran_gaussian(rng, 1.0);
         double y = gsl_ran_gaussian(rng, 1.0);
         double z = gsl_ran_gaussian(rng, 1.0);
         double norm = sqrt(x*x + y*y + z*z);
-        direction[i].x = x / norm;
-        direction[i].y = y / norm;
-        direction[i].z = z / norm;
+        direction_x[i] = x / norm;
+        direction_y[i] = y / norm;
+        direction_z[i] = z / norm;
     }
     update_endpoints();
 }
@@ -51,38 +79,64 @@ Filament::~Filament() {
 }
 
 // Copy constructor.
-Filament::Filament(const Filament& other) {
-    n = other.n;
-    box = other.box;
-    length = other.length;
-    cb_strength = other.cb_strength;
-    center = other.center;
-    direction = other.direction;
-    left_end = other.left_end;
-    right_end = other.right_end;
-    force = other.force;
-    torque = other.torque;
-    velocity = other.velocity;
+Filament::Filament(const Filament& other)
+    : n(other.n), box(other.box), length(other.length),
+      center(center_x, center_y, center_z),
+      direction(direction_x, direction_y, direction_z),
+      left_end(left_end_x, left_end_y, left_end_z),
+      right_end(right_end_x, right_end_y, right_end_z),
+      force(force_x, force_y, force_z),
+      torque(torque_x, torque_y, torque_z),
+      velocity(velocity_x, velocity_y, velocity_z),
+      custom_features(other.custom_features)
+{
+    center_x = other.center_x;
+    center_y = other.center_y;
+    center_z = other.center_z;
+    direction_x = other.direction_x;
+    direction_y = other.direction_y;
+    direction_z = other.direction_z;
+    left_end_x = other.left_end_x;
+    left_end_y = other.left_end_y;
+    left_end_z = other.left_end_z;
+    right_end_x = other.right_end_x;
+    right_end_y = other.right_end_y;
+    right_end_z = other.right_end_z;
+    force_x = other.force_x;
+    force_y = other.force_y;
+    force_z = other.force_z;
+    torque_x = other.torque_x;
+    torque_y = other.torque_y;
+    torque_z = other.torque_z;
+    velocity_x = other.velocity_x;
+    velocity_y = other.velocity_y;
+    velocity_z = other.velocity_z;
     f_load = other.f_load;
-    custom_features = other.custom_features;
+    cb_strength = other.cb_strength;
 }
 
 // Displace function (translation only).
 void Filament::displace(int& i, double& dx, double& dy, double& dz) {
-    center[i].x += dx;
-    center[i].y += dy;
-    center[i].z += dz;
-    center[i].pbc_wrap(box);
+    center_x[i] += dx;
+    center_y[i] += dy;
+    center_z[i] += dz;
+    vec temp{center_x[i], center_y[i], center_z[i]};
+    temp.pbc_wrap(box);
+    center_x[i] = temp.x;
+    center_y[i] = temp.y;
+    center_z[i] = temp.z;
     update_endpoints(i);
 }
 
-
 // Update endpoints for the i-th filament in 3D.
 void Filament::update_endpoints(int& i) {
-    left_end[i] = center[i] - 0.5 * length * direction[i];
-    right_end[i] = center[i] + 0.5 * length * direction[i];
+    left_end_x[i] = center_x[i] - 0.5 * length * direction_x[i];
+    left_end_y[i] = center_y[i] - 0.5 * length * direction_y[i];
+    left_end_z[i] = center_z[i] - 0.5 * length * direction_z[i];
+    right_end_x[i] = center_x[i] + 0.5 * length * direction_x[i];
+    right_end_y[i] = center_y[i] + 0.5 * length * direction_y[i];
+    right_end_z[i] = center_z[i] + 0.5 * length * direction_z[i];
 }
-
 
 // Update endpoints for all filaments.
 void Filament::update_endpoints() {
@@ -91,14 +145,24 @@ void Filament::update_endpoints() {
     }
 }
 
-
-
 // Update center positions for all filaments.
 void Filament::update_center(std::vector<vec> new_center) {
     for (int i = 0; i < n; i++) {
-        center[i] = new_center[i];
+        center_x[i] = new_center[i].x;
+        center_y[i] = new_center[i].y;
+        center_z[i] = new_center[i].z;
     }
     update_endpoints();
+}
+
+// Reduce thread-local vec arrays into a VecArray target
+void reduce_array(std::vector<std::vector<vec>>& temp_array, Filament::VecArray& target_array) {
+    #pragma omp for
+    for (size_t i = 0; i < target_array.size(); ++i) {
+        for (int t = 0; t < omp_get_num_threads(); ++t) {
+            target_array[i] += temp_array[t][i];
+        }
+    }
 }
 
 // Register a new 1D feature.

--- a/cpp/src/h5_utils.cpp
+++ b/cpp/src/h5_utils.cpp
@@ -25,7 +25,7 @@ std::vector<std::vector<int>> serializeActinIndicesPerActin(
 }
 
 
-std::vector<double> flatten_3d_array(std::vector<vec> array)
+std::vector<double> flatten_3d_array(const Filament::VecArray& array)
 {
     size_t rows = array.size();
     std::vector<double> flattened(rows * 3);

--- a/cpp/src/neighborlist.cpp
+++ b/cpp/src/neighborlist.cpp
@@ -47,10 +47,10 @@ NeighborList::NeighborList() {}
 
 // Compute the 3D cell index for a position using PBC.
 // Returns a tuple of (cell_x, cell_y, cell_z).
-std::tuple<int, int, int> NeighborList::get_cell_index(const vec& position) const {
-    int cell_x = static_cast<int>(std::floor((position.x + box_[0]) / cell_size_x_)) % num_cells_x_;
-    int cell_y = static_cast<int>(std::floor((position.y + box_[1]) / cell_size_y_)) % num_cells_y_;
-    int cell_z = static_cast<int>(std::floor((position.z + box_[2]) / cell_size_z_)) % num_cells_z_;
+std::tuple<int, int, int> NeighborList::get_cell_index(double x, double y, double z) const {
+    int cell_x = static_cast<int>(std::floor((x + box_[0]) / cell_size_x_)) % num_cells_x_;
+    int cell_y = static_cast<int>(std::floor((y + box_[1]) / cell_size_y_)) % num_cells_y_;
+    int cell_z = static_cast<int>(std::floor((z + box_[2]) / cell_size_z_)) % num_cells_z_;
 
     // Correct negative indices.
     cell_x = (cell_x % num_cells_x_ + num_cells_x_) % num_cells_x_;
@@ -61,23 +61,21 @@ std::tuple<int, int, int> NeighborList::get_cell_index(const vec& position) cons
 }
 
 // Initialize the neighbor list using separate actin and myosin positions.
-void NeighborList::initialize(const std::vector<vec>& actin_positions, const std::vector<vec>& myosin_positions) {
-    actin_positions_ = actin_positions;
-    n_actins_ = actin_positions.size();
-    myosin_positions_ = myosin_positions;
+void NeighborList::initialize(const std::vector<double>& actin_x, const std::vector<double>& actin_y, const std::vector<double>& actin_z,
+                              const std::vector<double>& myosin_x, const std::vector<double>& myosin_y, const std::vector<double>& myosin_z) {
+    // Store positions in structure-of-arrays form.
+    set_species_positions(actin_x, actin_y, actin_z, myosin_x, myosin_y, myosin_z);
 
     // Save current positions for later displacement checking.
-    last_actin_positions_ = actin_positions;
-    last_myosin_positions_ = myosin_positions;
-
-    // Concatenate positions into a single vector.
-    concatenate_positions();
-
-    // Record species type for each particle.
-    track_species_types();
+    last_actin_x_ = actin_x_;
+    last_actin_y_ = actin_y_;
+    last_actin_z_ = actin_z_;
+    last_myosin_x_ = myosin_x_;
+    last_myosin_y_ = myosin_y_;
+    last_myosin_z_ = myosin_z_;
 
     // Resize the neighbor list container.
-    neighbor_list_.resize(all_positions_.size());
+    neighbor_list_.resize(all_x_.size());
 
     // Build the neighbor list.
     rebuild_neighbor_list();
@@ -88,14 +86,14 @@ void NeighborList::initialize(const std::vector<vec>& actin_positions, const std
 // Helper function to clear and resize internal containers.
 void NeighborList::clearAndResizeContainers() {
     neighbor_list_.clear();
-    neighbor_list_.resize(all_positions_.size());
+    neighbor_list_.resize(all_x_.size());
     cell_list_.clear();
 }
 
 // Step 1: Populate the cell list with particle indices.
 void NeighborList::populateCellList() {
-    for (size_t i = 0; i < all_positions_.size(); ++i) {
-        auto cell = get_cell_index(all_positions_[i]);
+    for (size_t i = 0; i < all_x_.size(); ++i) {
+        auto cell = get_cell_index(all_x_[i], all_y_[i], all_z_[i]);
         cell_list_[cell].push_back(i);
     }
 }
@@ -107,7 +105,7 @@ void NeighborList::createThreadLocalStorage(
     tls.resize(omp_get_max_threads());
     #pragma omp parallel for
     for (auto& local_list : tls) {
-        local_list.resize(all_positions_.size());
+        local_list.resize(all_x_.size());
     }
 }
 
@@ -122,9 +120,8 @@ void NeighborList::computeNeighbors(
     {
         int thread_id = omp_get_thread_num();
         #pragma omp for schedule(dynamic)
-        for (size_t i = 0; i < all_positions_.size(); ++i) {
-            vec position = all_positions_[i];
-            auto cell = get_cell_index(position);
+        for (size_t i = 0; i < all_x_.size(); ++i) {
+            auto cell = get_cell_index(all_x_[i], all_y_[i], all_z_[i]);
             
             // Check particles in the current cell and its neighbors in 3D.
             for (const auto& offset_tuple : neighboring_cells) {
@@ -140,7 +137,13 @@ void NeighborList::computeNeighbors(
                 for (int j : cell_list_[neighbor_cell]) {
                     if (i >= static_cast<size_t>(j))
                         continue;
-                    double distance = all_positions_[i].distance(all_positions_[j], box_);
+                    double dx = all_x_[i] - all_x_[j];
+                    dx -= box_[0] * std::round(dx / box_[0]);
+                    double dy = all_y_[i] - all_y_[j];
+                    dy -= box_[1] * std::round(dy / box_[1]);
+                    double dz = all_z_[i] - all_z_[j];
+                    dz -= box_[2] * std::round(dz / box_[2]);
+                    double distance = std::sqrt(dx * dx + dy * dy + dz * dz);
                     if (distance < cutoff_radius_) {
                         tls[thread_id][i].emplace_back(j, species_types_[j]);
                         tls[thread_id][j].emplace_back(i, species_types_[i]);
@@ -157,7 +160,7 @@ void NeighborList::mergeThreadLocalLists(
     const std::vector<std::vector<std::vector<std::pair<size_t, ParticleType>>>> &tls)
 {
     #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < all_positions_.size(); ++i) {
+    for (size_t i = 0; i < all_x_.size(); ++i) {
         for (const auto& local_list : tls) {
             neighbor_list_[i].insert(
                 neighbor_list_[i].end(),
@@ -170,8 +173,12 @@ void NeighborList::mergeThreadLocalLists(
 
 // Step 5: Update last known positions.
 void NeighborList::updateLastKnownPositions() {
-    last_actin_positions_ = actin_positions_;
-    last_myosin_positions_ = myosin_positions_;
+    last_actin_x_ = actin_x_;
+    last_actin_y_ = actin_y_;
+    last_actin_z_ = actin_z_;
+    last_myosin_x_ = myosin_x_;
+    last_myosin_y_ = myosin_y_;
+    last_myosin_z_ = myosin_z_;
 }
 
 // Main rebuild function that calls each step.
@@ -268,10 +275,17 @@ void NeighborList::rebuild_neighbor_list() {
 // }
 
 // Set new positions for the two species.
-void NeighborList::set_species_positions(const std::vector<vec>& actin_positions, const std::vector<vec>& myosin_positions) {
-    actin_positions_ = actin_positions;
-    n_actins_ = actin_positions.size();
-    myosin_positions_ = myosin_positions;
+void NeighborList::set_species_positions(const std::vector<double>& actin_x, const std::vector<double>& actin_y, const std::vector<double>& actin_z,
+                                         const std::vector<double>& myosin_x, const std::vector<double>& myosin_y, const std::vector<double>& myosin_z) {
+    n_actins_ = actin_x.size();
+    actin_x_ = actin_x;
+    actin_y_ = actin_y;
+    actin_z_ = actin_z;
+
+    myosin_x_ = myosin_x;
+    myosin_y_ = myosin_y;
+    myosin_z_ = myosin_z;
+
     concatenate_positions();
     track_species_types();
 }
@@ -281,24 +295,26 @@ bool NeighborList::needs_rebuild() const {
     bool needs_rebuild = false;
     // Check actin displacements.
     #pragma omp parallel for
-    for (size_t i = 0; i < actin_positions_.size(); ++i) {
-        if (displacement(actin_positions_[i], last_actin_positions_[i]) > threshold_) {
+    for (size_t i = 0; i < actin_x_.size(); ++i) {
+        if (displacement(actin_x_[i], actin_y_[i], actin_z_[i],
+                         last_actin_x_[i], last_actin_y_[i], last_actin_z_[i]) > threshold_) {
             needs_rebuild = true;
             #pragma omp cancel for
         }
     }
-    #pragma omp barrier 
+    #pragma omp barrier
     if (needs_rebuild)
         return true;
     // Check myosin displacements.
     #pragma omp parallel for
-    for (size_t i = 0; i < myosin_positions_.size(); ++i) {
-        if (displacement(myosin_positions_[i], last_myosin_positions_[i]) > threshold_) {
+    for (size_t i = 0; i < myosin_x_.size(); ++i) {
+        if (displacement(myosin_x_[i], myosin_y_[i], myosin_z_[i],
+                         last_myosin_x_[i], last_myosin_y_[i], last_myosin_z_[i]) > threshold_) {
             needs_rebuild = true;
             #pragma omp cancel for
         }
     }
-    #pragma omp barrier 
+    #pragma omp barrier
     return needs_rebuild;
 }
 
@@ -326,22 +342,35 @@ std::pair<std::vector<int>, std::vector<int>> NeighborList::get_neighbors_by_typ
 
 
 // Compute the displacement between two positions (with periodic boundaries).
-double NeighborList::displacement(const vec& current, const vec& last) const {
-    return current.distance(last, box_);
+double NeighborList::displacement(double cx, double cy, double cz,
+                                  double lx, double ly, double lz) const {
+    double dx = cx - lx;
+    dx -= box_[0] * std::round(dx / box_[0]);
+    double dy = cy - ly;
+    dy -= box_[1] * std::round(dy / box_[1]);
+    double dz = cz - lz;
+    dz -= box_[2] * std::round(dz / box_[2]);
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
 }
 
 // Concatenate the positions from actin and myosin into one vector.
 void NeighborList::concatenate_positions() {
-    all_positions_.clear();
-    all_positions_.insert(all_positions_.end(), actin_positions_.begin(), actin_positions_.end());
-    all_positions_.insert(all_positions_.end(), myosin_positions_.begin(), myosin_positions_.end());
+    all_x_.clear();
+    all_y_.clear();
+    all_z_.clear();
+    all_x_.insert(all_x_.end(), actin_x_.begin(), actin_x_.end());
+    all_x_.insert(all_x_.end(), myosin_x_.begin(), myosin_x_.end());
+    all_y_.insert(all_y_.end(), actin_y_.begin(), actin_y_.end());
+    all_y_.insert(all_y_.end(), myosin_y_.begin(), myosin_y_.end());
+    all_z_.insert(all_z_.end(), actin_z_.begin(), actin_z_.end());
+    all_z_.insert(all_z_.end(), myosin_z_.begin(), myosin_z_.end());
 }
 
 // Track the species type for each particle in the concatenated list.
 void NeighborList::track_species_types() {
     species_types_.clear();
-    species_types_.insert(species_types_.end(), actin_positions_.size(), ParticleType::Actin);
-    species_types_.insert(species_types_.end(), myosin_positions_.size(), ParticleType::Myosin);
+    species_types_.insert(species_types_.end(), actin_x_.size(), ParticleType::Actin);
+    species_types_.insert(species_types_.end(), myosin_x_.size(), ParticleType::Myosin);
 }
 
 

--- a/cpp/src/sarcomere_2d.cpp
+++ b/cpp/src/sarcomere_2d.cpp
@@ -51,7 +51,8 @@ Sarcomere::Sarcomere(int& n_actins, int& n_myosins, std::vector<double> box0, do
                             std::max(2 * myosin_radius, crosslinker_length);
             double skin_distance = 0.15 * cutoff_radius;
             neighbor_list = NeighborList(cutoff_radius + skin_distance, box, skin_distance / 2);
-            neighbor_list.initialize(actin.center, myosin.center);
+            neighbor_list.initialize(actin.center_x, actin.center_y, actin.center_z,
+                                    myosin.center_x, myosin.center_y, myosin.center_z);
             actin_actin_bonds_prev = actin_actin_bonds;
             actin_basic_tension.resize(n_actins);
             actin_crosslink_ratio.resize(n_actins);
@@ -374,7 +375,8 @@ void Sarcomere::update_system_sterics_only() {
 
 
 void Sarcomere::_update_neighbors() {
-    neighbor_list.set_species_positions(actin.center, myosin.center);
+    neighbor_list.set_species_positions(actin.center_x, actin.center_y, actin.center_z,
+                                       myosin.center_x, myosin.center_y, myosin.center_z);
     // Clear previous neighbors data and prepare to store new neighbors
     actin_neighbors_by_species.clear();
     actin_neighbors_by_species.resize(actin.center.size());

--- a/cpp/tests.cpp
+++ b/cpp/tests.cpp
@@ -1,6 +1,52 @@
 #include "gtest/gtest.h"
 #include "include/utils.h"
+#include "include/sarcomere.h"
+#include <chrono>
+#include <iostream>
 #include <cmath>
+
+TEST(NeighborList, RebuildTiming)
+{
+    int n_actins = 1500;
+    int n_myosins = 130;
+    std::vector<double> box{6.0, 4.0, 3.2};
+    double actin_length = 1.0;
+    double myosin_length = 1.5;
+    double myosin_radius = 0.4;
+    double myosin_radius_ratio = 0.4;
+    double crosslinker_length = 0.06;
+    double k_on = 1000.0;
+    double k_off = 1.0;
+    double base_lifetime = 0.001;
+    double lifetime_coeff = 0.4;
+    double diff_coeff_ratio = 10.0; // 0.5 / 0.05 from run_test.sh defaults
+    double k_aa = 300.0;
+    double kappa_aa = 50.0;
+    double k_am = 50.0;
+    double kappa_am = 200.0;
+    double v_am = 5.0;
+    std::string filename = "test.h5";
+    gsl_rng* rng = gsl_rng_alloc(gsl_rng_mt19937);
+    int seed = 0;
+    int fix_myosin = 0;
+    double dt = 0.00001;
+    bool directional = true;
+
+    Sarcomere model(n_actins, n_myosins, box, actin_length, myosin_length,
+                    myosin_radius, myosin_radius_ratio, crosslinker_length,
+                    k_on, k_off, base_lifetime, lifetime_coeff, diff_coeff_ratio,
+                    k_aa, kappa_aa, k_am, kappa_am, v_am,
+                    filename, rng, seed, fix_myosin, dt, directional);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    model.neighbor_list.set_species_positions(model.actin.center_x, model.actin.center_y, model.actin.center_z,
+                                              model.myosin.center_x, model.myosin.center_y, model.myosin.center_z);
+    model.neighbor_list.rebuild_neighbor_list();
+    auto end = std::chrono::high_resolution_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(end - start).count();
+    std::cout << "Neighbor list rebuild took " << ms << " ms" << std::endl;
+    gsl_rng_free(rng);
+}
 
 TEST(Vec, Distance)
 {


### PR DESCRIPTION
## Summary
- Store filament coordinates and other vector fields in a structure-of-arrays layout with lightweight references for vector math
- Update neighbor list and sarcomere logic to consume separate x/y/z arrays and provide a reduction helper for VecArray targets
- Add a gtest that builds a full simulation with run_test.sh parameters and reports neighbor-list rebuild timing

## Testing
- `g++ -std=c++17 cpp/tests.cpp cpp/src/components.cpp cpp/src/neighborlist.cpp cpp/src/sarcomere.cpp cpp/src/langevin.cpp cpp/src/interaction.cpp cpp/src/geometry.cpp cpp/src/utils.cpp cpp/src/h5_utils.cpp -Icpp/include -Icpp/autodiff -I/usr/include/hdf5/serial -I/usr/include/eigen3 -fopenmp -L/usr/lib/x86_64-linux-gnu/hdf5/serial -lgsl -lgslcblas -lhdf5_cpp -lhdf5 -lgtest -lgtest_main -pthread -o cpp/tests && ./cpp/tests`

------
https://chatgpt.com/codex/tasks/task_e_688bfda44ef08333bc4ddbb7319dab14