### PR TITLE
Use myosin direction for cross-bridge alignment bias

### DIFF
--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -874,7 +874,8 @@ void Sarcomere::_apply_cb_alignment_bias(double& k_theta_bias)
 {
     #pragma omp for
         for (int i = 0; i < myosin.n; ++i) {
-            vec u      = myosin.torque[i];                   // unit orientation
+            vec u = myosin.direction[i];
+            u.normalize();
             auto idxs   = actinIndicesPerMyosin.getConnections(i);
 
             double acc_cb = 1.0; // accumulated cross-bridge strength


### PR DESCRIPTION
## Summary
- Normalize and use `myosin.direction` when applying cross-bridge alignment bias instead of `myosin.torque`.

## Testing
- `g++ -std=c++17 tests.cpp src/sarcomere.cpp src/geometry.cpp src/interaction.cpp src/utils.cpp src/neighborlist.cpp src/h5_utils.cpp src/components.cpp src/langevin.cpp -Iinclude -lgsl -lgslcblas -lhdf5 -fopenmp -o tests && ./tests` *(fails: gtest/gtest.h, gsl/gsl_rng.h, autodiff/forward/real.hpp, H5Cpp.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68913c4895d083338d98473023d9bd14