### PR TITLE
Add catch-bond debug metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /movie.mp4
 /test.pdf
 /test_actin.jl
+cpp/build/

--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -34,6 +34,15 @@ public:
     std::vector<std::vector<int>> actin_actin_bonds, actin_actin_bonds_prev;
     // Track lifetime (in steps) for each actin–actin catch bond
     std::vector<std::vector<int>> actin_actin_lifetime, actin_actin_lifetime_prev;
+    // Per-frame catch-bond statistics
+    struct CbStats {
+        int close_opposite_pairs;
+        int pairs_diff_myosin;
+        double avg_lifetime;
+        double max_lifetime;
+    };
+    // History of statistics for each debug call
+    std::vector<CbStats> cb_stats_history;
     vector box;
     double k_aa, kappa_aa, cb_mult_factor, k_on, k_off,
            kappa_am, k_am, v_am, crosslinker_length, myosin_radius_ratio, skin_distance, cutoff_radius,
@@ -78,8 +87,10 @@ public:
     void new_file();
     void save_state();
     void load_state(int& n_frames);
-    // Debug helper to report catch-bond statistics for a single frame
-    void debug_cb_stats();
+    // Debug helper to compute catch-bond statistics for a single frame
+    CbStats debug_cb_stats();
+    // Retrieve all recorded catch-bond statistics
+    const std::vector<CbStats>& get_cb_stats_history() const { return cb_stats_history; }
 
 private:
     // Private helper methods

--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -34,15 +34,6 @@ public:
     std::vector<std::vector<int>> actin_actin_bonds, actin_actin_bonds_prev;
     // Track lifetime (in steps) for each actin–actin catch bond
     std::vector<std::vector<int>> actin_actin_lifetime, actin_actin_lifetime_prev;
-    // Per-frame catch-bond statistics
-    struct CbStats {
-        int close_opposite_pairs;
-        int pairs_diff_myosin;
-        double avg_lifetime;
-        double max_lifetime;
-    };
-    // History of statistics for each debug call
-    std::vector<CbStats> cb_stats_history;
     vector box;
     double k_aa, kappa_aa, cb_mult_factor, k_on, k_off,
            kappa_am, k_am, v_am, crosslinker_length, myosin_radius_ratio, skin_distance, cutoff_radius,
@@ -88,9 +79,7 @@ public:
     void save_state();
     void load_state(int& n_frames);
     // Debug helper to compute catch-bond statistics for a single frame
-    CbStats debug_cb_stats();
-    // Retrieve all recorded catch-bond statistics
-    const std::vector<CbStats>& get_cb_stats_history() const { return cb_stats_history; }
+    void debug_cb_stats();
 
 private:
     // Private helper methods

--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -32,6 +32,8 @@ public:
     utils::MoleculeConnection actinIndicesPerActin;
 
     std::vector<std::vector<int>> actin_actin_bonds, actin_actin_bonds_prev;
+    // Track lifetime (in steps) for each actin–actin catch bond
+    std::vector<std::vector<int>> actin_actin_lifetime, actin_actin_lifetime_prev;
     vector box;
     double k_aa, kappa_aa, cb_mult_factor, k_on, k_off,
            kappa_am, k_am, v_am, crosslinker_length, myosin_radius_ratio, skin_distance, cutoff_radius,
@@ -76,6 +78,8 @@ public:
     void new_file();
     void save_state();
     void load_state(int& n_frames);
+    // Debug helper to report catch-bond statistics for a single frame
+    void debug_cb_stats();
 
 private:
     // Private helper methods

--- a/cpp/src/langevin.cpp
+++ b/cpp/src/langevin.cpp
@@ -64,6 +64,7 @@ void Langevin::run_langevin(int nsteps, gsl_rng* rng, int& fix_myosin) {
             start = omp_get_wtime();
         }
         model.update_system();
+        model.debug_cb_stats();
         sample_step(dt, rng, fix_myosin);
         if (i % save_every == 0) {
             end = omp_get_wtime();

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -800,7 +800,7 @@ void Sarcomere::_set_cb(int& i, std::vector<int> indices, vector cb_strength){
     }
 }
 
-Sarcomere::CbStats Sarcomere::debug_cb_stats(){
+void Sarcomere::debug_cb_stats(){
     int close_opposite = 0;
     int diff_myosin = 0;
     for(int i=0;i<actin.n;i++){
@@ -821,7 +821,12 @@ Sarcomere::CbStats Sarcomere::debug_cb_stats(){
                                 break;
                             }
                         }
-                        if(!shared) diff_myosin++;
+                        if(!shared){
+                            diff_myosin++;
+                            std::cout << "Pair " << i << "-" << j
+                                      << " cb_strengths: " << actin.cb_strength[i]
+                                      << ", " << actin.cb_strength[j] << std::endl;
+                        }
                     }
                 }
             }
@@ -841,13 +846,10 @@ Sarcomere::CbStats Sarcomere::debug_cb_stats(){
         }
     }
     double avg_life = active>0 ? total_life/active : 0.0;
-    CbStats stats{close_opposite, diff_myosin, avg_life, max_life};
-    cb_stats_history.push_back(stats);
-    std::cout << "CB Debug: close_opposite_pairs=" << stats.close_opposite_pairs
-              << ", pairs_diff_myosin=" << stats.pairs_diff_myosin
-              << ", avg_lifetime=" << stats.avg_lifetime
-              << ", max_lifetime=" << stats.max_lifetime << std::endl;
-    return stats;
+    std::cout << "CB Debug: close_opposite_pairs=" << close_opposite
+              << ", pairs_diff_myosin=" << diff_myosin
+              << ", avg_lifetime=" << avg_life
+              << ", max_lifetime=" << max_life << std::endl;
 }
 
 

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -800,7 +800,7 @@ void Sarcomere::_set_cb(int& i, std::vector<int> indices, vector cb_strength){
     }
 }
 
-void Sarcomere::debug_cb_stats(){
+Sarcomere::CbStats Sarcomere::debug_cb_stats(){
     int close_opposite = 0;
     int diff_myosin = 0;
     for(int i=0;i<actin.n;i++){
@@ -841,10 +841,13 @@ void Sarcomere::debug_cb_stats(){
         }
     }
     double avg_life = active>0 ? total_life/active : 0.0;
-    std::cout << "CB Debug: close_opposite_pairs=" << close_opposite
-              << ", pairs_diff_myosin=" << diff_myosin
-              << ", avg_lifetime=" << avg_life
-              << ", max_lifetime=" << max_life << std::endl;
+    CbStats stats{close_opposite, diff_myosin, avg_life, max_life};
+    cb_stats_history.push_back(stats);
+    std::cout << "CB Debug: close_opposite_pairs=" << stats.close_opposite_pairs
+              << ", pairs_diff_myosin=" << stats.pairs_diff_myosin
+              << ", avg_lifetime=" << stats.avg_lifetime
+              << ", max_lifetime=" << stats.max_lifetime << std::endl;
+    return stats;
 }
 
 


### PR DESCRIPTION
## Summary
- Track catch-bond lifetimes and add debug utility printing candidate actin pairs and bond statistics.
- Log per-frame catch-bond metrics from the Langevin loop for easier diagnosis of sparse bonding.

## Testing
- `bash run_test.sh` *(fails: `nohup: failed to run command 'build/sarcomere': No such file or directory`)*
- `cmake ..`
- `make -j4`
- `./sarcomere --nsteps=10 --n_actins=5 --n_myosins=2 --save_every=5 --directional=true --filename=../../data/test.h5`

------
https://chatgpt.com/codex/tasks/task_e_688d41233154833394b52502c9d08487