### PR TITLE
Plot time-dependent catch bond ratios

### DIFF
--- a/analysis/analyze_catch_bonds.py
+++ b/analysis/analyze_catch_bonds.py
@@ -63,9 +63,9 @@ def analyze_catch_bonds(h5file: str, dt: float = 1.0, prefix: str = "analysis") 
         # Collect all actin directions across frames for a global distribution
         all_dirs = []
 
-        # Percentages of filaments engaged in catch bonds per frame
-        pct_actin_cb: list[float] = []
-        pct_myosin_cb: list[float] = []
+        # Ratios of filaments engaged in catch bonds per frame
+        ratio_actin_cb: list[float] = []
+        ratio_myosin_cb: list[float] = []
 
         for frame in range(n_frames):
             bonds = bonds_ds[frame]
@@ -105,12 +105,12 @@ def analyze_catch_bonds(h5file: str, dt: float = 1.0, prefix: str = "analysis") 
                         "count": 1,
                     }
 
-            # Percentage of actins engaged in catch bonds (cb_strength > 0.001)
+            # Ratio of actins engaged in catch bonds (cb_strength > 0.001)
             n_actins = cb_strength_frame.shape[0]
             catch_actins = [i for i in bonded_actins if cb_strength_frame[i] > 0.001]
-            pct_actin_cb.append(100.0 * len(catch_actins) / max(n_actins, 1))
+            ratio_actin_cb.append(len(catch_actins) / max(n_actins, 1))
 
-            # Percentage of myosins engaged in catch bond
+            # Ratio of myosins engaged in catch bond
             if myosin_bonds_ds is not None:
                 myo_bonds = myosin_bonds_ds[frame]
                 n_myosins = 250
@@ -121,7 +121,7 @@ def analyze_catch_bonds(h5file: str, dt: float = 1.0, prefix: str = "analysis") 
                         continue
                     bonded_myosins.update([m, n])
                 catch_myosins = [i for i in bonded_myosins]
-                pct_myosin_cb.append(100.0 * len(catch_myosins) / max(n_myosins, 1))
+                ratio_myosin_cb.append(len(catch_myosins) / max(n_myosins, 1))
 
             # Close out bonds that ended this frame
             ended = [p for p in active if p not in current_pairs]
@@ -178,30 +178,26 @@ def analyze_catch_bonds(h5file: str, dt: float = 1.0, prefix: str = "analysis") 
         plt.savefig(f"{prefix}_actin_direction_angle_to_x.png", dpi=300)
         plt.close()
 
-    # Time series of catch bond engagement percentages
-    if pct_actin_cb:
+    # Time series of catch bond engagement ratios
+    if ratio_actin_cb:
+        times = np.arange(len(ratio_actin_cb)) * dt
         plt.figure()
-        plt.plot(pct_actin_cb)
-        plt.xlabel("Frame")
-        plt.ylabel("Actins in catch bond (%)")
+        plt.plot(times, ratio_actin_cb)
+        plt.xlabel("Time")
+        plt.ylabel("Actins in catch bond (ratio)")
         plt.tight_layout()
-        plt.savefig(f"{prefix}_actin_catch_bond_percentage.png", dpi=300)
+        plt.savefig(f"{prefix}_actin_catch_bond_ratio.png", dpi=300)
         plt.close()
-        print(
-            f"Mean actin catch bond percentage: {float(np.mean(pct_actin_cb)):.2f}%"
-        )
 
-    if pct_myosin_cb:
+    if ratio_myosin_cb:
+        times = np.arange(len(ratio_myosin_cb)) * dt
         plt.figure()
-        plt.plot(pct_myosin_cb)
-        plt.xlabel("Frame")
-        plt.ylabel("Myosins in catch bond (%)")
+        plt.plot(times, ratio_myosin_cb)
+        plt.xlabel("Time")
+        plt.ylabel("Myosins in catch bond (ratio)")
         plt.tight_layout()
-        plt.savefig(f"{prefix}_myosin_catch_bond_percentage.png", dpi=300)
+        plt.savefig(f"{prefix}_myosin_catch_bond_ratio.png", dpi=300)
         plt.close()
-        print(
-            f"Mean myosin catch bond percentage: {float(np.mean(pct_myosin_cb)):.2f}%"
-        )
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Track per-frame ratios of actins and myosins engaged in catch bonds.
- Plot time-dependent catch bond ratios using simulation timestep for the x-axis.

## Testing
- `pytest`
- `python analysis/analyze_catch_bonds.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9a097e883338cf238fde378ca7d