### PR TITLE
Limit myosin bond connections

### DIFF
--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -34,6 +34,8 @@ public:
     std::vector<std::vector<int>> actin_actin_bonds, actin_actin_bonds_prev;
     // Track lifetime (in steps) for each actin–actin catch bond
     std::vector<std::vector<int>> actin_actin_lifetime, actin_actin_lifetime_prev;
+    // Store normalized strength for each actin–actin bond
+    std::vector<std::vector<double>> actin_actin_strength;
     // Track actin–myosin bonds for kinetic Monte Carlo updates
     std::vector<std::vector<int>> am_bonds, am_bonds_prev;
     // Store previous actin load used for k_off calculations
@@ -44,6 +46,8 @@ public:
            dt, base_lifetime, lifetime_coeff, diff_coeff_ratio;
     bool directional;
     int fix_myosin;
+    int max_myosin_bonds;
+    int max_strong_actin_bonds;
     std::vector<std::vector<interaction>> am_interaction;
     vector actin_crosslink_ratio;
     std::vector<int> actin_n_bonds;
@@ -65,7 +69,11 @@ public:
     Sarcomere(int& n_actins, int& n_myosins, vector box0, double& actin_length, double& myosin_length,
         double& myosin_radius, double& myosin_radius_ratio, double& crosslinker_length, double& k_on, double& k_off,
         double& base_lifetime, double& lifetime_coeff, double& diff_coeff_ratio, double& k_aa, double& kappa_aa, double& k_am, double& kappa_am, double& v_am,
-        std::string& filename, gsl_rng* rng, int& seed, int& fix_myosin, double& dt, bool& directional);
+        std::string& filename, gsl_rng* rng, int& seed, int& fix_myosin, double& dt, bool& directional, int max_myosin_bonds = 2, int max_strong_actin_bonds = 1);
+    Sarcomere(int& n_actins, int& n_myosins, vector box0, double& actin_length, double& myosin_length,
+        double& myosin_radius, double& myosin_radius_ratio, double& crosslinker_length, double& k_on,
+        double& base_lifetime, double& lifetime_coeff, double& diff_coeff_ratio, double& k_aa, double& kappa_aa, double& k_am, double& kappa_am, double& v_am,
+        std::string& filename, gsl_rng* rng, int& seed, int& fix_myosin, double& dt, bool& directional, std::string& boundary_condition, int max_myosin_bonds = 2, int max_strong_actin_bonds = 1);
     ~Sarcomere();
 
     // Public Methods
@@ -105,6 +113,8 @@ private:
     std::pair<std::vector<double>, std::vector<double>>  _extract_bonded_pairs(
         const std::vector<std::vector<int>>& actin_actin_bonds,
         const utils::MoleculeConnection& myosinIndicesPerActin);
+    void _enforce_myosin_bond_limit();
+    void _enforce_actin_cb_limit();
 };
 
 #endif // SARCOMERE_H

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -2,13 +2,13 @@
 #include <algorithm>
 
 // Constructor
-Sarcomere::Sarcomere() {}
+Sarcomere::Sarcomere() : max_myosin_bonds(2), max_strong_actin_bonds(1) {}
 
 // Parameterized Constructor
 Sarcomere::Sarcomere(int& n_actins, int& n_myosins, vector box0, double& actin_length, double& myosin_length,
         double& myosin_radius, double& myosin_radius_ratio, double& crosslinker_length, double& k_on, double& k_off,
         double& base_lifetime, double& lifetime_coeff, double& diff_coeff_ratio, double& k_aa, double& kappa_aa, double& k_am, double& kappa_am, double& v_am,
-        std::string& filename, gsl_rng* rng, int& seed, int& fix_myosin, double& dt, bool& directional)
+        std::string& filename, gsl_rng* rng, int& seed, int& fix_myosin, double& dt, bool& directional, int max_myosin_bonds, int max_strong_actin_bonds)
             : actin(n_actins, actin_length, box0, rng),
               myosin(n_myosins, myosin_length, myosin_radius, box0, rng),
               myosinIndicesPerActin(n_actins),
@@ -16,6 +16,7 @@ Sarcomere::Sarcomere(int& n_actins, int& n_myosins, vector box0, double& actin_l
               neighbor_list(0.0, box0, 0.0),
                 actin_actin_bonds(n_actins, std::vector<int>(n_actins, 0)),
                 actin_actin_lifetime(n_actins, std::vector<int>(n_actins, 0)),
+                actin_actin_strength(n_actins, std::vector<double>(n_actins, 0)),
                 am_bonds(n_actins, std::vector<int>(n_myosins, 0)),
                 actin_forces_temp(omp_get_max_threads(), std::vector<vec>(n_actins, {0, 0, 0})),
                 myosin_forces_temp(omp_get_max_threads(), std::vector<vec>(n_myosins, {0, 0, 0})),
@@ -50,6 +51,8 @@ Sarcomere::Sarcomere(int& n_actins, int& n_myosins, vector box0, double& actin_l
             this->lifetime_coeff = lifetime_coeff;
             this->diff_coeff_ratio = diff_coeff_ratio;
             this->directional = directional;
+            this->max_myosin_bonds = max_myosin_bonds;
+            this->max_strong_actin_bonds = max_strong_actin_bonds;
             cb_mult_factor = 1000;
             cutoff_radius = std::max(actin_length, myosin_length) +
                             std::max(2 * myosin_radius/myosin_radius_ratio, crosslinker_length);
@@ -262,8 +265,13 @@ void Sarcomere::update_system() {
         // Step 4: Reduce actin catch-bond strengths
         utils::reduce_array(actin_cb_strengths_temp, actin.cb_strength);
 
-
-        #pragma omp barrier  
+        #pragma omp barrier
+        #pragma omp single
+        {
+            _enforce_actin_cb_limit();
+            _enforce_myosin_bond_limit();
+        }
+        #pragma omp barrier
 
         // Step 5: Concatenate actinIndicesPerMyosin connections
         #pragma omp for
@@ -402,6 +410,7 @@ void Sarcomere::_set_to_zero() {
             actin_actin_bonds[i][j] = 0;
             actin_actin_lifetime_prev[i][j] = actin_actin_lifetime[i][j];
             actin_actin_lifetime[i][j] = 0;
+            actin_actin_strength[i][j] = 0;
         }
         for (int j = 0; j < myosin.n; j++){
             am_bonds_prev[i][j] = am_bonds[i][j];
@@ -492,6 +501,75 @@ void Sarcomere::_process_catch_bonds(int& i) {
             }
     }
     _set_cb(i, cb_indices,cb_strengths);
+}
+
+void Sarcomere::_enforce_myosin_bond_limit() {
+    for (int j = 0; j < myosin.n; ++j) {
+        std::vector<int> bound_actins;
+        for (int i = 0; i < actin.n; ++i) {
+            if (am_bonds[i][j] == 1) {
+                bound_actins.push_back(i);
+            }
+        }
+
+        if (static_cast<int>(bound_actins.size()) <= max_myosin_bonds) {
+            continue;
+        }
+
+        std::vector<int> priority(bound_actins.size(), 0);
+        for (size_t idx = 0; idx < bound_actins.size(); ++idx) {
+            int i = bound_actins[idx];
+            bool cb = actin.cb_strength[i] > 0;
+            bool prev = am_bonds_prev[i][j] == 1;
+            if (cb && prev) priority[idx] = 3;
+            else if (cb) priority[idx] = 2;
+            else if (prev) priority[idx] = 1;
+        }
+
+        auto order = utils::sort_indices(priority);
+        for (size_t k = max_myosin_bonds; k < order.size(); ++k) {
+            int actin_idx = bound_actins[order[k]];
+            am_bonds[actin_idx][j] = 0;
+            myosinIndicesPerActin.deleteConnection(actin_idx, j);
+            for (auto& temp_conn : actinIndicesPerMyosin_temp) {
+                temp_conn.deleteConnection(j, actin_idx);
+            }
+        }
+    }
+}
+
+void Sarcomere::_enforce_actin_cb_limit() {
+    double threshold = 1.0 / cb_mult_factor;
+    for (int i = 0; i < actin.n; ++i) {
+        std::vector<int> strong_partners;
+        for (int j = 0; j < actin.n; ++j) {
+            if (actin_actin_bonds[i][j] == 1 && actin_actin_strength[i][j] > threshold) {
+                strong_partners.push_back(j);
+            }
+        }
+        if (static_cast<int>(strong_partners.size()) <= max_strong_actin_bonds) {
+            continue;
+        }
+        std::sort(strong_partners.begin(), strong_partners.end(), [&](int a, int b) {
+            int pa = (actin_actin_bonds_prev[i][a] == 1) ? 1 : 0;
+            int pb = (actin_actin_bonds_prev[i][b] == 1) ? 1 : 0;
+            if (pa != pb) return pa > pb;
+            return actin_actin_strength[i][a] > actin_actin_strength[i][b];
+        });
+        for (size_t k = max_strong_actin_bonds; k < strong_partners.size(); ++k) {
+            int j = strong_partners[k];
+            double strength = actin_actin_strength[i][j];
+            actin_actin_bonds[i][j] = actin_actin_bonds[j][i] = 0;
+            actin_actin_strength[i][j] = actin_actin_strength[j][i] = 0;
+            actin_actin_lifetime[i][j] = actin_actin_lifetime[j][i] = 0;
+            actin_n_bonds[i]--;
+            actin_n_bonds[j]--;
+            actin.cb_strength[i] -= strength;
+            actin.cb_strength[j] -= strength;
+            if (actin.cb_strength[i] < 0) actin.cb_strength[i] = 0;
+            if (actin.cb_strength[j] < 0) actin.cb_strength[j] = 0;
+        }
+    }
 }
 
 void Sarcomere::_calc_am_force_velocity(int& i) {
@@ -810,6 +888,8 @@ void Sarcomere::_set_cb(int& i, int& j, double& normalized_strength, bool& add_c
     actin_n_bonds[j] += 1;
     actin_actin_bonds[i][j] = 1;
     actin_actin_bonds[j][i] = 1;
+    actin_actin_strength[i][j] = normalized_strength;
+    actin_actin_strength[j][i] = normalized_strength;
     // Update lifetime: increment if bond persisted, reset if new
     actin_actin_lifetime[i][j] = actin_actin_lifetime_prev[i][j] + 1;
     actin_actin_lifetime[j][i] = actin_actin_lifetime[i][j];

--- a/cpp/src/sarcomere_2d.cpp
+++ b/cpp/src/sarcomere_2d.cpp
@@ -1,13 +1,14 @@
 #include "sarcomere.h"
+#include <algorithm>
 
 // Constructor
-Sarcomere::Sarcomere() {}
+Sarcomere::Sarcomere() : max_myosin_bonds(2), max_strong_actin_bonds(1) {}
 
 // Parameterized Constructor
 Sarcomere::Sarcomere(int& n_actins, int& n_myosins, std::vector<double> box0, double& actin_length, double& myosin_length,
               double& myosin_radius, double& myosin_radius_ratio, double& crosslinker_length, double& k_on,
               double& base_lifetime, double& lifetime_coeff, double& diff_coeff_ratio, double& k_aa, double& kappa_aa, double& k_am, double& kappa_am, double& v_am,
-              std::string& filename, gsl_rng* rng, int& seed, int& fix_myosin, double& dt, bool& directional, std::string& boundary_condition) :
+              std::string& filename, gsl_rng* rng, int& seed, int& fix_myosin, double& dt, bool& directional, std::string& boundary_condition, int max_myosin_bonds, int max_strong_actin_bonds) :
             pbc_mask(utils::parse_pbc_mask(boundary_condition)),
             actin(n_actins, actin_length, box0, pbc_mask, rng),
             myosin(n_myosins, myosin_length, myosin_radius, box0, pbc_mask, rng),
@@ -15,6 +16,7 @@ Sarcomere::Sarcomere(int& n_actins, int& n_myosins, std::vector<double> box0, do
             actinIndicesPerMyosin(n_myosins),
             neighbor_list(0.0, box0, 0.0),
             actin_actin_bonds(n_actins, std::vector<int>(n_actins, 0)),
+            actin_actin_strength(n_actins, std::vector<double>(n_actins, 0)),
             am_bonds(n_actins, std::vector<int>(n_myosins, 0)),
             actin_forces_temp(omp_get_max_threads(), std::vector<vec>(n_actins, {0, 0})),
             myosin_forces_temp(omp_get_max_threads(), std::vector<vec>(n_myosins, {0, 0})),
@@ -47,6 +49,8 @@ Sarcomere::Sarcomere(int& n_actins, int& n_myosins, std::vector<double> box0, do
             this->lifetime_coeff = lifetime_coeff;
             this->diff_coeff_ratio = diff_coeff_ratio;
             this->directional = directional;
+            this->max_myosin_bonds = max_myosin_bonds;
+            this->max_strong_actin_bonds = max_strong_actin_bonds;
             cb_mult_factor = 1000;
             cutoff_radius = std::max(actin_length, myosin_length) +
                             std::max(2 * myosin_radius, crosslinker_length);
@@ -298,7 +302,13 @@ void Sarcomere::update_system() {
 
         // Step 4: Reduce actin catch-bond strengths
         utils::reduce_array(actin_cb_strengths_temp, actin.cb_strength);
-        #pragma omp barrier  
+        #pragma omp barrier
+        #pragma omp single
+        {
+            _enforce_actin_cb_limit();
+            _enforce_myosin_bond_limit();
+        }
+        #pragma omp barrier
 
         // Step 5: Concatenate actinIndicesPerMyosin connections
         #pragma omp for
@@ -432,6 +442,7 @@ void Sarcomere::_set_to_zero() {
         for (int j = 0; j < actin.n; j++){
             actin_actin_bonds_prev[i][j] = actin_actin_bonds[i][j];
             actin_actin_bonds[i][j] = 0;
+            actin_actin_strength[i][j] = 0;
         }
         for (int j = 0; j < myosin.n; j++){
             am_bonds_prev[i][j] = am_bonds[i][j];
@@ -520,6 +531,74 @@ void Sarcomere::_process_catch_bonds(int& i) {
             }
     }
     _set_cb(i, cb_indices,cb_strengths);
+}
+
+void Sarcomere::_enforce_myosin_bond_limit() {
+    for (int j = 0; j < myosin.n; ++j) {
+        std::vector<int> bound_actins;
+        for (int i = 0; i < actin.n; ++i) {
+            if (am_bonds[i][j] == 1) {
+                bound_actins.push_back(i);
+            }
+        }
+
+        if (static_cast<int>(bound_actins.size()) <= max_myosin_bonds) {
+            continue;
+        }
+
+        std::vector<int> priority(bound_actins.size(), 0);
+        for (size_t idx = 0; idx < bound_actins.size(); ++idx) {
+            int i = bound_actins[idx];
+            bool cb = actin.cb_strength[i] > 0;
+            bool prev = am_bonds_prev[i][j] == 1;
+            if (cb && prev) priority[idx] = 3;
+            else if (cb) priority[idx] = 2;
+            else if (prev) priority[idx] = 1;
+        }
+
+        auto order = utils::sort_indices(priority);
+        for (size_t k = max_myosin_bonds; k < order.size(); ++k) {
+            int actin_idx = bound_actins[order[k]];
+            am_bonds[actin_idx][j] = 0;
+            myosinIndicesPerActin.deleteConnection(actin_idx, j);
+            for (auto& temp_conn : actinIndicesPerMyosin_temp) {
+                temp_conn.deleteConnection(j, actin_idx);
+            }
+        }
+    }
+}
+
+void Sarcomere::_enforce_actin_cb_limit() {
+    double threshold = 1.0 / cb_mult_factor;
+    for (int i = 0; i < actin.n; ++i) {
+        std::vector<int> strong_partners;
+        for (int j = 0; j < actin.n; ++j) {
+            if (actin_actin_bonds[i][j] == 1 && actin_actin_strength[i][j] > threshold) {
+                strong_partners.push_back(j);
+            }
+        }
+        if (static_cast<int>(strong_partners.size()) <= max_strong_actin_bonds) {
+            continue;
+        }
+        std::sort(strong_partners.begin(), strong_partners.end(), [&](int a, int b) {
+            int pa = (actin_actin_bonds_prev[i][a] == 1) ? 1 : 0;
+            int pb = (actin_actin_bonds_prev[i][b] == 1) ? 1 : 0;
+            if (pa != pb) return pa > pb;
+            return actin_actin_strength[i][a] > actin_actin_strength[i][b];
+        });
+        for (size_t k = max_strong_actin_bonds; k < strong_partners.size(); ++k) {
+            int j = strong_partners[k];
+            double strength = actin_actin_strength[i][j];
+            actin_actin_bonds[i][j] = actin_actin_bonds[j][i] = 0;
+            actin_actin_strength[i][j] = actin_actin_strength[j][i] = 0;
+            actin_n_bonds[i]--;
+            actin_n_bonds[j]--;
+            actin.cb_strength[i] -= strength;
+            actin.cb_strength[j] -= strength;
+            if (actin.cb_strength[i] < 0) actin.cb_strength[i] = 0;
+            if (actin.cb_strength[j] < 0) actin.cb_strength[j] = 0;
+        }
+    }
 }
 
 void Sarcomere::_calc_am_force_velocity(int& i) {
@@ -819,11 +898,13 @@ void Sarcomere::_set_cb(int& i, int& j, double& normalized_strength, bool& add_c
     local_actin_angular_forces[i] += force_vec[2];
     local_actin_angular_forces[j] += force_vec[3]; 
     local_actin_cb_strengths[i] += normalized_strength;
-    local_actin_cb_strengths[j] += normalized_strength;
-    actin_n_bonds[i] += 1;
-    actin_n_bonds[j] += 1;
-    actin_actin_bonds[i][j] = 1;
-    actin_actin_bonds[j][i] = 1;
+   local_actin_cb_strengths[j] += normalized_strength;
+   actin_n_bonds[i] += 1;
+   actin_n_bonds[j] += 1;
+   actin_actin_bonds[i][j] = 1;
+   actin_actin_bonds[j][i] = 1;
+   actin_actin_strength[i][j] = normalized_strength;
+   actin_actin_strength[j][i] = normalized_strength;
 }
 
 void Sarcomere::_set_cb(int& i, std::vector<int> indices, std::vector<double> cb_strength){


### PR DESCRIPTION
## Summary
- Add `max_strong_actin_bonds` and per-bond strength tracking to restrict strong catch bonds per actin
- Trim excess strong actin-actin bonds in 3D and 2D update loops before force calculations
- Enforce both actin and myosin bond caps during system updates

## Testing
- `cmake --build build`
- `bash run_test.sh` *(fails: numactl command not found; missing visualize_traj.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d380fae08333a628411b751f649e