### PR TITLE
Refine actin-myosin bond extraction

### DIFF
--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -1016,13 +1016,14 @@ std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>
         flattenedMyosinBonds.push_back(static_cast<double>(bond.second));
     }
 
-    // Extract actin–myosin bonds from actinIndicesPerMyosin.
+    // Extract actin–myosin bonds directly from the bond matrix.
     std::vector<double> flatActinMyosinBonds;
-    for (int m = 0; m < myosin.n; ++m) {
-        auto actins = actinIndicesPerMyosin.getConnections(m);
-        for (int a : actins) {
-            flatActinMyosinBonds.push_back(static_cast<double>(a));
-            flatActinMyosinBonds.push_back(static_cast<double>(m));
+    for (int a = 0; a < actin.n; ++a) {
+        for (int m = 0; m < myosin.n; ++m) {
+            if (am_bonds[a][m] == 1) {
+                flatActinMyosinBonds.push_back(static_cast<double>(a));
+                flatActinMyosinBonds.push_back(static_cast<double>(m));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Derive actin-myosin bonded pair list by scanning `am_bonds` instead of connection lists.

## Testing
- `cmake ..`
- `make -j2`
- `./sarcomere --nsteps=10 --save_every=2 --n_actins=5 --n_myosins=3 --filename=../../data/test.h5`
- `python analyze_catch_bonds.py ../data/test.h5 --dt 0.02 --prefix ../data/analysis`


------
https://chatgpt.com/codex/tasks/task_e_68a57b522c7883338f0449d583ff9427