### PR TITLE
Parameterize actin-myosin bond capacity

### DIFF
--- a/cpp/include/h5_utils.h
+++ b/cpp/include/h5_utils.h
@@ -38,13 +38,15 @@ void append_to_dataset(H5::Group& group, const std::string& datasetName,
                        const std::vector<hsize_t>& newDims);
 
 // Create a new HDF5 file and set up datasets for actin and myosin.
-void create_file(std::string& filename, Filament& actin, Myosin& myosin);
+void create_file(std::string& filename, Filament& actin, Myosin& myosin,
+                 int max_myosin_bonds);
 
 // Append simulation data (actin, myosin, energy, connection indices) to the file.
 void append_to_file(std::string& filename, Filament& actin, Myosin& myosin,
     std::vector<double>& flatActinBonds,
     std::vector<double>& flatMyosinBonds,
-    std::vector<double>& flatActinMyosinBonds);
+    std::vector<double>& flatActinMyosinBonds,
+    int max_myosin_bonds);
 
 // Load data from a dataset into a 1D vector of doubles.
 // The dataset dimensions are returned in the dims vector.

--- a/cpp/src/h5_utils.cpp
+++ b/cpp/src/h5_utils.cpp
@@ -144,7 +144,8 @@ void append_to_dataset(H5::Group& group, const std::string& datasetName,
     }
 }
 
-void create_file(std::string& filename, Filament& actin, Myosin& myosin)
+void create_file(std::string& filename, Filament& actin, Myosin& myosin,
+                 int max_myosin_bonds)
 {
     // Remove any existing file with the same name.
     std::remove(filename.c_str());
@@ -214,7 +215,7 @@ void create_file(std::string& filename, Filament& actin, Myosin& myosin)
     chunkDims   = {10, max_n_myosin_bonds, 2};
     create_empty_dataset(file, "/myosin", "bonds", initialDims, maxDims, chunkDims);
 
-    hsize_t max_n_am_bonds = n_myosins * 2;
+    hsize_t max_n_am_bonds = n_myosins * max_myosin_bonds;
     initialDims = {0, max_n_am_bonds, 2};
     maxDims     = {H5S_UNLIMITED, max_n_am_bonds, 2};
     chunkDims   = {10, max_n_am_bonds, 2};
@@ -225,7 +226,8 @@ void create_file(std::string& filename, Filament& actin, Myosin& myosin)
 void append_to_file(std::string& filename, Filament& actin, Myosin& myosin,
     std::vector<double>& flatActinBonds,
     std::vector<double>& flatMyosinBonds,
-    std::vector<double>& flatActinMyosinBonds)
+    std::vector<double>& flatActinMyosinBonds,
+    int max_myosin_bonds)
 
 {
     H5::H5File file(filename, H5F_ACC_RDWR);
@@ -282,7 +284,7 @@ void append_to_file(std::string& filename, Filament& actin, Myosin& myosin,
     // Compute maximum possible bonds per frame.
     int max_n_actin_bonds = actin.n * 5;
     int max_n_myosin_bonds = myosin.n * 4;
-    int max_n_am_bonds = myosin.n * 2;
+    int max_n_am_bonds = myosin.n * max_myosin_bonds;
 
     // Compute current number of bonds (each bond occupies two entries).
     int current_n_actinBonds = static_cast<int>(flatActinBonds.size()) / 2;

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -1071,7 +1071,7 @@ void Sarcomere::_apply_cb_alignment_bias(double& k_theta_bias)
 
 
 void Sarcomere::new_file(){
-    create_file(filename, actin, myosin);
+    create_file(filename, actin, myosin, max_myosin_bonds);
 }
 
 void Sarcomere::save_state(){
@@ -1081,7 +1081,7 @@ void Sarcomere::save_state(){
     std::vector<double> flatMyosinBonds = std::get<1>(bondData);
     std::vector<double> flatActinMyosinBonds = std::get<2>(bondData);
     append_to_file(filename, actin, myosin, flatActinBonds,
-                   flatMyosinBonds, flatActinMyosinBonds);
+                   flatMyosinBonds, flatActinMyosinBonds, max_myosin_bonds);
 }
 
 void Sarcomere::load_state(int& n_frames){

--- a/cpp/src/sarcomere_2d.cpp
+++ b/cpp/src/sarcomere_2d.cpp
@@ -1027,7 +1027,7 @@ void Sarcomere::_apply_cb_alignment_bias(double& k_theta_bias) {
 
 
 void Sarcomere::new_file(){
-    create_file(filename, actin, myosin);
+    create_file(filename, actin, myosin, max_myosin_bonds);
 }
 
 void Sarcomere::save_state(){
@@ -1037,7 +1037,7 @@ void Sarcomere::save_state(){
     std::vector<double> flatMyosinBonds = std::get<1>(bondData);
     std::vector<double> flatActinMyosinBonds = std::get<2>(bondData);
     append_to_file(filename, actin, myosin, flatActinBonds,
-                   flatMyosinBonds, flatActinMyosinBonds);
+                   flatMyosinBonds, flatActinMyosinBonds, max_myosin_bonds);
 }
 
 void Sarcomere::load_state(int& n_frames){


### PR DESCRIPTION
## Summary
- make HDF5 actin-myosin bond datasets scale with configurable myosin bond limit
- propagate `max_myosin_bonds` from `Sarcomere` to HDF5 helpers
- adjust save/load utilities to use the supplied bond capacity

## Testing
- `cmake ..`
- `make -j2`


------
https://chatgpt.com/codex/tasks/task_e_68a57cc482788333928035c714c09644