### PR TITLE
Remove KMC step for actin-myosin bonds

### DIFF
--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -36,10 +36,8 @@ public:
     std::vector<std::vector<double>> actin_actin_strength;
     // Track lifetime (in steps) for each actin–actin catch bond
     std::vector<std::vector<int>> actin_actin_lifetime, actin_actin_lifetime_prev;
-    // Track actin–myosin bonds for kinetic Monte Carlo updates
+    // Track actin–myosin bonds
     std::vector<std::vector<int>> am_bonds, am_bonds_prev;
-    // Store previous actin load used for k_off calculations
-    std::vector<double> actin_f_load_prev;
     vector box;
     double k_aa, kappa_aa, cb_mult_factor, k_on, k_off,
            kappa_am, k_am, v_am, crosslinker_length, myosin_radius_ratio, skin_distance, cutoff_radius,

--- a/cpp/src/sarcomere_2d.cpp
+++ b/cpp/src/sarcomere_2d.cpp
@@ -72,7 +72,6 @@ Sarcomere::Sarcomere(int& n_actins, int& n_myosins, std::vector<double> box0, do
             for (int i = 0; i < n_actins; i++) {
                 am_interaction[i].resize(n_myosins);
             }
-            actin_f_load_prev.resize(n_actins, 0.0);
             actin.register_feature("myosin_binding_ratio");
             actin.register_feature("crosslink_ratio");
             actin.register_feature("partial_binding_ratio");
@@ -429,7 +428,6 @@ void Sarcomere::_set_to_zero() {
         actin.force[i] = {0, 0};
         actin.angular_force[i] = 0;
         actin.velocity[i] = {0, 0};
-        actin_f_load_prev[i] = actin.f_load[i];
         actin.f_load[i] = 0;
         actin.cb_strength[i] = 0;
         actin_basic_tension[i] = 0;
@@ -499,19 +497,8 @@ void Sarcomere::_process_actin_myosin_binding(int& i) {
                     actin["myosin_binding_ratio"][i] = am_interaction[i][j].myosin_binding_ratio;
                 }
 
-                // Determine bond state via KMC scheme
-                double rand = gsl_rng_uniform(rng_engines[thread_id]);
-                bool was_bound = am_bonds_prev[i][j] == 1;
-                if (was_bound) {
-                    double k_off_adjusted = dt /(base_lifetime + lifetime_coeff * actin_f_load_prev[i]);
-                    if (rand >= k_off_adjusted) {
-                        am_bonds[i][j] = 1;
-                    }
-                } else {
-                    if (rand < k_on * dt) {
-                        am_bonds[i][j] = 1;
-                    }
-                }
+                // Immediately register a bond when geometrically allowed
+                am_bonds[i][j] = 1;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove stochastic KMC logic for actin–myosin binding in favor of deterministic attachment once geometry permits.
- Clean up sarcomere class by dropping unused KMC-related state.

## Testing
- `cmake ..`
- `make -j2`
- `bash run_test.sh` *(fails: numactl: command not found; missing visualize_traj.py)*
- `g++ tests.cpp src/*.cpp -Iinclude -Iautodiff -fopenmp -lgsl -lgslcblas -lhdf5 -lhdf5_cpp -o tests` *(fails: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a580ee1ec883338e88ae59fa4c8861