### PR TITLE
Replace catch-bond strength with status

### DIFF
--- a/analysis/analyze_catch_bonds.py
+++ b/analysis/analyze_catch_bonds.py
@@ -49,7 +49,7 @@ def analyze_catch_bonds(h5file: str, dt: float = 1.0, prefix: str = "analysis") 
         bonds_ds = fh["/actin/bonds"]
         dirs_ds = fh["/actin/direction"]
         fload_ds = fh["/actin/f_load"]
-        cb_strength_actin = fh["/actin/cb_strength"]
+        cb_status_actin = fh["/actin/cb_status"]
 
         actin_vel_ds = fh["/actin/velocity"]
         myosin_vel_ds = fh["/myosin/velocity"] if "/myosin/velocity" in fh else None
@@ -85,7 +85,7 @@ def analyze_catch_bonds(h5file: str, dt: float = 1.0, prefix: str = "analysis") 
             bonds = bonds_ds[frame]
             dirs = np.asarray(dirs_ds[frame])  # (N,3)
             f_load = fload_ds[frame, :, 0]     # (N,)
-            cb_strength_frame = cb_strength_actin[frame, :, 0]
+            cb_strength_frame = cb_status_actin[frame, :, 0]
 
             actin_speed = np.linalg.norm(actin_vel_ds[frame], axis=1)
             actin_speeds.extend(actin_speed)
@@ -127,9 +127,9 @@ def analyze_catch_bonds(h5file: str, dt: float = 1.0, prefix: str = "analysis") 
                         "count": 1,
                     }
 
-            # Ratio of actins engaged in catch bonds (cb_strength > 0.01)
+            # Ratio of actins engaged in catch bonds (cb_status > 0)
             n_actins = cb_strength_frame.shape[0]
-            catch_actins = [i for i in bonded_actins if cb_strength_frame[i] > 0.01]
+            catch_actins = [i for i in bonded_actins if cb_strength_frame[i] > 0]
             ratio_actin_cb.append(len(catch_actins) / max(n_actins, 1))
 
             # Actin--myosin connectivity for this frame

--- a/analysis/visualize_traj.py
+++ b/analysis/visualize_traj.py
@@ -145,7 +145,7 @@ def plot_system(frame, data, myosin_length, actin_length, Lx, Ly, Lz, myosin_rad
     # Actin
     actin_center = data["/actin/center"][frame]
     actin_direction = data["/actin/direction"][frame]
-    cb_strength = data["/actin/cb_strength"][frame].flatten()
+    cb_strength = data["/actin/cb_status"][frame].flatten()
     f_load = data["/actin/f_load"][frame].flatten()
     plot_filaments_3d(
         center=actin_center,
@@ -363,11 +363,11 @@ if __name__ == "__main__":
     frame_range = range(start_frame, end_frame)
     if args.print_frame < nframes:
         actin_center = data["/actin/center"][args.print_frame]
-        cb_strength = data["/actin/cb_strength"][args.print_frame]
+        cb_strength = data["/actin/cb_status"][args.print_frame]
         f_load = data["/actin/f_load"][args.print_frame]
         for i in range(actin_center.shape[0]):
-            if cb_strength[i] > 0.01:
-                print(f"Actin filament {i}: catch bond strength: {cb_strength[i]}")
+            if cb_strength[i] > 0:
+                print(f"Actin filament {i}: catch bond status: {cb_strength[i]}")
                 print(f"Actin filament {i}: f load: {f_load[i]}")
                 print(f"Actin filament {i}: center: {actin_center[i]}")
         myosin_center = data["/myosin/center"][args.print_frame]

--- a/analysis/visualize_traj3d.py
+++ b/analysis/visualize_traj3d.py
@@ -163,7 +163,7 @@ def plot_system(frame, data, myosin_length, actin_length, Lx, Ly, Lz, myosin_rad
     # Actin data.
     actin_center = data["/actin/center"][frame]
     actin_direction = data["/actin/direction"][frame]
-    cb_strength = data["/actin/cb_strength"][frame].flatten()
+    cb_strength = data["/actin/cb_status"][frame].flatten()
     f_load = data["/actin/f_load"][frame].flatten()
     actin_direction = data["/actin/direction"][frame]  # shape (N, 3)
     plot_filaments_3d(actin_center, actin_direction, actin_length,
@@ -373,11 +373,11 @@ if __name__ == "__main__":
     print(f"Number of frames: {nframes}")
     if args.print_frame < nframes:
         actin_center = data["/actin/center"][args.print_frame]
-        cb_strength = data["/actin/cb_strength"][args.print_frame]
+        cb_strength = data["/actin/cb_status"][args.print_frame]
         f_load = data["/actin/f_load"][args.print_frame]
         for i in range(actin_center.shape[0]):
-            if cb_strength[i] > 0.01:
-                print(f"Actin filament {i}: catch bond strength: {cb_strength[i]}")
+            if cb_strength[i] > 0:
+                print(f"Actin filament {i}: catch bond status: {cb_strength[i]}")
                 print(f"Actin filament {i}: f load: {f_load[i]}")
                 print(f"Actin filament {i}: center: {actin_center[i]}")
         myosin_center = data["/myosin/center"][args.print_frame]

--- a/cpp/include/components.h
+++ b/cpp/include/components.h
@@ -31,7 +31,7 @@ public:
     std::vector<double> torque_x, torque_y, torque_z;
     std::vector<double> velocity_x, velocity_y, velocity_z;
     std::vector<double> f_load;
-    std::vector<double> cb_strength;
+    std::vector<int> cb_status;
 
     struct VecRef {
         double &x, &y, &z;

--- a/cpp/include/h5_utils.h
+++ b/cpp/include/h5_utils.h
@@ -31,10 +31,18 @@ void create_empty_dataset(H5::H5File& file, const std::string& groupName,
                           const std::vector<hsize_t>& initialDims,
                           const std::vector<hsize_t>& maxDims,
                           const std::vector<hsize_t>& chunkDims);
+void create_empty_dataset_int(H5::H5File& file, const std::string& groupName,
+                          const std::string& datasetName,
+                          const std::vector<hsize_t>& initialDims,
+                          const std::vector<hsize_t>& maxDims,
+                          const std::vector<hsize_t>& chunkDims);
 
 // Append new data to an existing dataset within a given group.
 void append_to_dataset(H5::Group& group, const std::string& datasetName,
                        const std::vector<double> newData,
+                       const std::vector<hsize_t>& newDims);
+void append_to_dataset_int(H5::Group& group, const std::string& datasetName,
+                       const std::vector<int> newData,
                        const std::vector<hsize_t>& newDims);
 
 // Create a new HDF5 file and set up datasets for actin and myosin.

--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -33,13 +33,13 @@ public:
     utils::MoleculeConnection actinIndicesPerActin;
 
     std::vector<std::vector<int>> actin_actin_bonds, actin_actin_bonds_prev;
-    std::vector<std::vector<double>> actin_actin_strength;
+    std::vector<std::vector<int>> actin_actin_status;
     // Track lifetime (in steps) for each actin–actin catch bond
     std::vector<std::vector<int>> actin_actin_lifetime, actin_actin_lifetime_prev;
     // Track actin–myosin bonds
     std::vector<std::vector<int>> am_bonds, am_bonds_prev;
     vector box;
-    double k_aa, kappa_aa, cb_mult_factor, k_on, k_off,
+    double k_aa, kappa_aa, k_on, k_off,
            kappa_am, k_am, v_am, crosslinker_length, myosin_radius_ratio, skin_distance, cutoff_radius,
            dt, base_lifetime, lifetime_coeff, diff_coeff_ratio;
     bool directional;
@@ -57,9 +57,10 @@ public:
     gsl_rng* rng;
     std::string filename;
 
-    std::vector<std::vector<vec>> actin_forces_temp, 
+    std::vector<std::vector<vec>> actin_forces_temp,
                                     myosin_forces_temp, myosin_velocities_temp, actin_torques_temp, myosin_torques_temp;
-    std::vector<std::vector<double>> actin_cb_strengths_temp, myosin_f_load_temp;
+    std::vector<std::vector<int>> actin_cb_status_temp;
+    std::vector<std::vector<double>> myosin_f_load_temp;
     std::vector<utils::MoleculeConnection> actinIndicesPerMyosin_temp;
     std::vector<gsl_rng*> rng_engines;
 
@@ -103,10 +104,10 @@ private:
     void _myosin_exclusion();
     void _myosin_repulsion(int& i, int& j);
     void _actin_repulsion(int& i, int& j);
-    double _get_cb_strength(int& i, int& j);
-    void _get_f_load(int& i);
-    void _set_cb(int& i, int& j, double& normalized_strength, bool& add_connection);
-    void _set_cb(int& i, std::vector<int> indices, vector cb_strength);
+    int determine_cb_status(int& i, int& j);
+    void compute_actin_f_load(int& i);
+    void _set_cb(int& i, int& j, int status, bool& add_connection);
+    void _set_cb(int& i, std::vector<int> indices, std::vector<int> status);
     vec _alignment_torque(const vec& u, double k_bias);
     void _apply_cb_alignment_bias(double& k_theta_bias);
     std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>

--- a/cpp/src/components.cpp
+++ b/cpp/src/components.cpp
@@ -55,7 +55,7 @@ Filament::Filament(int n0, double length0, std::vector<double> box0, gsl_rng* rn
     velocity_y.resize(n);
     velocity_z.resize(n);
     f_load.resize(n);
-    cb_strength.resize(n);
+    cb_status.resize(n);
 
     // Randomly initialize the center positions and directions.
     for (int i = 0; i < n; i++) {
@@ -112,7 +112,7 @@ Filament::Filament(const Filament& other)
     velocity_y = other.velocity_y;
     velocity_z = other.velocity_z;
     f_load = other.f_load;
-    cb_strength = other.cb_strength;
+    cb_status = other.cb_status;
 }
 
 // Displace function (translation only).

--- a/cpp/src/langevin.cpp
+++ b/cpp/src/langevin.cpp
@@ -131,7 +131,7 @@ void Langevin::sample_step(double& dt, gsl_rng* rng, int& fix_myosin) {
     }
     // Update actin particles.
     for (int i = 0; i < model.actin.n; i++) {
-        if (model.actin.cb_strength[i] > 1e-3){
+        if (model.actin.cb_status[i] > 0){
             D = D_myosin_trans;
             D_rot = D_myosin_rot;
         }

--- a/cpp/tests.cpp
+++ b/cpp/tests.cpp
@@ -95,11 +95,11 @@ TEST(Sarcomere, ActinStrongBondLimit)
 
     model.actin_actin_bonds[0][1] = model.actin_actin_bonds[1][0] = 1;
     model.actin_actin_bonds[0][2] = model.actin_actin_bonds[2][0] = 1;
-    model.actin_actin_strength[0][1] = model.actin_actin_strength[1][0] = 2.0;
-    model.actin_actin_strength[0][2] = model.actin_actin_strength[2][0] = 1.5;
-    model.actin.cb_strength[0] = 3.5;
-    model.actin.cb_strength[1] = 2.0;
-    model.actin.cb_strength[2] = 1.5;
+    model.actin_actin_status[0][1] = model.actin_actin_status[1][0] = 2;
+    model.actin_actin_status[0][2] = model.actin_actin_status[2][0] = 2;
+    model.actin.cb_status[0] = 2;
+    model.actin.cb_status[1] = 1;
+    model.actin.cb_status[2] = 2;
     model.actin_n_bonds[0] = 2;
     model.actin_n_bonds[1] = 1;
     model.actin_n_bonds[2] = 1;
@@ -113,8 +113,8 @@ TEST(Sarcomere, ActinStrongBondLimit)
 
     EXPECT_EQ(model.actin_actin_bonds[0][1], 1);
     EXPECT_EQ(model.actin_actin_bonds[0][2], 0);
-    EXPECT_DOUBLE_EQ(model.actin.cb_strength[0], 2.0);
-    EXPECT_DOUBLE_EQ(model.actin.cb_strength[2], 0.0);
+    EXPECT_EQ(model.actin.cb_status[0], 2);
+    EXPECT_EQ(model.actin.cb_status[2], 0);
     EXPECT_EQ(model.actin_n_bonds[0], 1);
     EXPECT_EQ(model.actin_n_bonds[2], 0);
     EXPECT_EQ(model.actin_actin_lifetime[0][2], 0);


### PR DESCRIPTION
## Summary
- Track catch bonds using integer `cb_status` fields and remove legacy strength scaling.
- Add cross-bond evaluation and load computation helpers, wiring them into force/velocity calculations and HDF5 output.
- Update analysis scripts and tests to consume the new `cb_status` dataset.

## Testing
- ❌ `bash run_test.sh` *(missing `numactl` and `h5py`)*
- ⚠️ `cmake -S cpp -B build` *(missing `GSL` library)*

------
https://chatgpt.com/codex/tasks/task_e_68a655051ffc83338fd7f54fd6c8bacb