### PR TITLE
Fix cross-bridge status determination

### DIFF
--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -775,7 +775,7 @@ int Sarcomere::determine_cb_status(int& i, int& j){
     }
     for (int mi : myosin_indices_i){
         for (int mj : myosin_indices_j){
-            if (mi != mj){
+            if (mi == mj){
                 return 2;
             }
         }


### PR DESCRIPTION
## Summary
- ensure cross-bridge status 2 requires a shared myosin between actins
- add regression test for cross-bridge status classification

## Testing
- `cmake ..`
- `make`
- `g++ -std=c++17 ../tests.cpp ... -o tests`
- `./tests`


------
https://chatgpt.com/codex/tasks/task_e_68a660ef1f188333a35797f1fe84f425