### PR TITLE
Make compute_actin_f_load thread-safe

### DIFF
--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <tuple>
 #include <omp.h>
+#include <mutex>
 
 #include "components.h"
 #include "utils.h"
@@ -53,6 +54,8 @@ public:
     std::vector<int> n_myosins_per_actin;
     std::vector<std::pair<std::vector<int>, std::vector<int>>> actin_neighbors_by_species;
     vector actin_basic_tension;
+    std::vector<bool> actin_f_load_computed;
+    std::vector<std::mutex> actin_f_load_mutex;
         
     gsl_rng* rng;
     std::string filename;


### PR DESCRIPTION
## Summary
- ensure actin load calculation occurs only once per actin using per-actin mutexes and flags
- reset computed flags during system initialization to allow recomputation

## Testing
- `cmake .. && make -j2` *(fails: Could NOT find GSL)*

------
https://chatgpt.com/codex/tasks/task_e_68a69dc12db88333a29ca204f27e3386