### PR TITLE
Plot actins with positive load

### DIFF
--- a/analysis/visualize_traj.py
+++ b/analysis/visualize_traj.py
@@ -150,9 +150,9 @@ def plot_system(frame, data, myosin_length, actin_length, Lx, Ly, Lz,
     # ------------------------------------------------------------------
     actin_center = data["/actin/center"][frame]
     actin_direction = data["/actin/direction"][frame]
-    cb_status = data["/actin/cb_status"][frame].flatten()
+    f_load = data["/actin/f_load"][frame].flatten()
 
-    mask = cb_status == 2
+    mask = f_load > 0
     actin_center = actin_center[mask]
     actin_direction = actin_direction[mask]
 


### PR DESCRIPTION
## Summary
- Plot actin filaments only when their `f_load` is positive, ensuring visualization focuses on loaded actins.

## Testing
- `python -m py_compile analysis/visualize_traj.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6a3fb65e48333a57be7f1878c8418