### PR TITLE
Fix max_myosin_bonds command line parsing

### DIFF
--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -79,7 +79,8 @@ int main(int argc, char* argv[]){
             ("n_fixed_myosins", "Number of fixed myosins", cxxopts::value<int>(n_fixed_myosins)->default_value("0"))
             ("filename", "Filename", cxxopts::value<std::string>(filename)->default_value("data/traj.h5"))
             ("initial_structure", "Type of initial structure", cxxopts::value<std::string>(init_struc)->default_value("random"))
-            ("max_myosin_bonds", "Maximum actin bonds per myosin", cxxopts::value<int>()->default_value("5"))
+            ("max_myosin_bonds", "Maximum actin bonds per myosin",
+             cxxopts::value<int>(max_myosin_bonds)->default_value("5"))
             ("h, help", "Print usage");
 
         auto result = options.parse(argc, argv);


### PR DESCRIPTION
## Summary
- Fix main.cpp to store the value of `--max_myosin_bonds` into the variable passed to `Sarcomere`

## Testing
- `make -j$(nproc)`
- `./sarcomere --nsteps=400 --n_actins=10 --n_myosins=2 --max_myosin_bonds=5 --filename=test.h5`


------
https://chatgpt.com/codex/tasks/task_e_68a6fbf071448333862d3b93bfd9445a