### PR TITLE
Add 2D simulation option

### DIFF
--- a/cpp/include/langevin.h
+++ b/cpp/include/langevin.h
@@ -20,7 +20,7 @@ public:
     // Note: Parameters are passed by reference as in the original code.
     Langevin(Sarcomere& model0, double& beta0, double& dt0, double& D0_actin_trans,
         double& D0_actin_rot, double& D0_myosin_trans, double& D0_myosin_rot,
-        int& save_every0, bool& resume);
+        int& save_every0, bool& resume, bool is3D);
     // Destructor.
     ~Langevin();
 
@@ -32,6 +32,7 @@ public:
 
     // Data members.
     double dt, beta, D_actin_trans, D_actin_rot, D_myosin_trans, D_myosin_rot;
+    bool is3D;
     int save_every, start_step;
     Sarcomere& model;
 };

--- a/cpp/run_test.sh
+++ b/cpp/run_test.sh
@@ -1,5 +1,6 @@
 export OMP_NUM_THREADS=12
 rm langevin_fix.out
-numactl --interleave=all nohup build/sarcomere  --n_actins=2000 --n_myosins=250 --filename=../data/1000actin.h5 --initial_structure=partial --Lx=5 --Ly=5 --Lz=5 --nsteps=100000 --save_every=200 --n_fixed_myosins=0 > langevin_fix.out &
+DIMENSION=${1:-3}
+numactl --interleave=all nohup build/sarcomere  --n_actins=2000 --n_myosins=250 --filename=../data/1000actin.h5 --initial_structure=partial --Lx=5 --Ly=5 --Lz=5 --dimension=${DIMENSION} --nsteps=100000 --save_every=200 --n_fixed_myosins=0 > langevin_fix.out &
 wait
 python ../analysis/visualize_traj.py --filename=../data/1000actin.h5 --print_frame=-1 --Lx=5 --Ly=5 --Lz=5 --frame_dir=1000actin --myosin_radius=0.15

--- a/cpp/src/benchmark.cpp
+++ b/cpp/src/benchmark.cpp
@@ -62,8 +62,9 @@ public:
             filename,rng, seed, n_fixed_myosins, dt, directional, 5);
 
         // Create the Langevin simulation instance.
+        bool is3D = true;
         sim = new Langevin(*model, beta, dt, actin_diff_coeff_trans,actin_diff_coeff_rot,
-             myosin_diff_coeff_trans, myosin_diff_coeff_rot, save_every, resume);
+             myosin_diff_coeff_trans, myosin_diff_coeff_rot, save_every, resume, is3D);
 
         // Set up the initial structure.
         if (!resume) {


### PR DESCRIPTION
## Summary
- allow selecting 2D or 3D simulations with new `--dimension` CLI option
- keep z coordinates pinned to zero in 2D mode via updated Langevin integrator
- extend run script to forward the dimension flag

## Testing
- `cmake ..`
- `cmake --build .`
- `./sarcomere --nsteps=1 --dimension=2 --n_actins=1 --n_myosins=1 --Lx=1 --Ly=1 --Lz=1 --save_every=1 --filename=../test.h5`

------
https://chatgpt.com/codex/tasks/task_e_68a94d95deb083339c6a95837a85db02