### PR TITLE
Ensure catch bond status requires active myosin binding

### DIFF
--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -762,7 +762,9 @@ int Sarcomere::determine_cb_status(int& i, int& j){
         return 1;
     }
     for (int mi : myosin_indices_i){
+        if (am_bonds[i][mi] != 1) continue;
         for (int mj : myosin_indices_j){
+            if (am_bonds[j][mj] != 1) continue;
             if (mi != mj){
                 return 2;
             }


### PR DESCRIPTION
## Summary
- Require both actins to be actively bound to different myosins before classifying catch bond status as strong

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68aec56fc5088333ab8e5623d0abccd5