### PR TITLE
Record catch-bond break metrics and add analysis

### DIFF
--- a/analysis/analyze_catch_bonds.py
+++ b/analysis/analyze_catch_bonds.py
@@ -33,6 +33,39 @@ def compute_pair_fload(
     return f_load, angle
 
 
+def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis") -> None:
+    """Read recorded catch-bond breakage events and plot distance and angle vs time."""
+    with h5py.File(h5file, "r") as fh:
+        if "/catch_bond/breakage" not in fh:
+            print("No catch-bond breakage data found in file")
+            return
+        data = np.asarray(fh["/catch_bond/breakage"])
+
+    if data.size == 0:
+        return
+
+    steps = data[:, 2]
+    times = steps * dt
+    distances = data[:, 3]
+    angles = np.degrees(np.arccos(np.clip(data[:, 4], -1.0, 1.0)))
+
+    plt.figure()
+    plt.scatter(times, distances, s=10, alpha=0.7)
+    plt.xlabel("Time")
+    plt.ylabel("Segment distance at break")
+    plt.tight_layout()
+    plt.savefig(f"{prefix}_cb_break_distance_vs_time.png", dpi=300)
+    plt.close()
+
+    plt.figure()
+    plt.scatter(times, angles, s=10, alpha=0.7)
+    plt.xlabel("Time")
+    plt.ylabel("Angle at break (deg)")
+    plt.tight_layout()
+    plt.savefig(f"{prefix}_cb_break_angle_vs_time.png", dpi=300)
+    plt.close()
+
+
 def analyze_catch_bonds(h5file: str, dt: float = 1.0,
                         prefix: str = "analysis",
                         start_frame: int = 0) -> None:
@@ -332,6 +365,7 @@ def main() -> None:
                         dt=args.dt,
                         prefix=args.prefix,
                         start_frame=args.start_frame)
+    plot_breakage_events(args.h5file, dt=args.dt, prefix=args.prefix)
 
 if __name__ == "__main__":
     main()

--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -10,6 +10,7 @@
 #include <tuple>
 #include <omp.h>
 #include <mutex>
+#include <cstddef>
 
 #include "components.h"
 #include "utils.h"
@@ -66,6 +67,11 @@ public:
     std::vector<std::vector<double>> myosin_f_load_temp;
     std::vector<utils::MoleculeConnection> actinIndicesPerMyosin_temp;
     std::vector<gsl_rng*> rng_engines;
+
+    // Record the global simulation step and catch-bond breakage events
+    size_t current_step = 0;
+    // Flat buffer storing (i, j, step, distance, cos_angle) for each breakage
+    std::vector<double> cb_breakage_events;
 
     // Constructors & Destructor
     Sarcomere();

--- a/cpp/src/h5_utils.cpp
+++ b/cpp/src/h5_utils.cpp
@@ -270,6 +270,13 @@ void create_file(std::string& filename, Filament& actin, Myosin& myosin,
     maxDims     = {H5S_UNLIMITED, max_n_am_bonds, 2};
     chunkDims   = {10, max_n_am_bonds, 2};
     create_empty_dataset(file, "/actin_myo", "bonds", initialDims, maxDims, chunkDims);
+
+    // Dataset to record catch-bond breakage events:
+    // columns: i, j, step, distance, cos_angle
+    initialDims = {0, 5};
+    maxDims     = {H5S_UNLIMITED, 5};
+    chunkDims   = {10, 5};
+    create_empty_dataset(file, "/catch_bond", "breakage", initialDims, maxDims, chunkDims);
 }
 
 

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -240,6 +240,8 @@ void Sarcomere::sarcomeric_structure(){
 
 
 void Sarcomere::update_system() {
+    // Advance global step counter each time the system is updated
+    current_step++;
     _update_neighbors();
     #pragma omp parallel
     {   
@@ -323,6 +325,8 @@ void Sarcomere::update_system() {
 
 
 void Sarcomere::update_system_sterics_only() {
+    // Advance step counter as well for sterics-only updates
+    current_step++;
     _update_neighbors();
     #pragma omp parallel
     {   
@@ -737,28 +741,46 @@ void Sarcomere::_actin_repulsion(int& i, int& j){
 }
 
 int Sarcomere::determine_cb_status(int& i, int& j){
+    // Compute geometric metrics used for diagnostics
+    double distance = geometry::segment_segment_distance(
+        actin.left_end[i], actin.right_end[i], actin.left_end[j], actin.right_end[j], box);
+    double cos_angle = actin.direction[i].dot(actin.direction[j]);
+
+    bool was_strong = (actin_actin_status[i][j] == 2);
     bool crosslink = false;
     if (actin_crosslink_ratio[i] > EPS && actin_crosslink_ratio[j] > EPS || ! directional){
-        double distance = geometry::segment_segment_distance(actin.left_end[i],
-            actin.right_end[i], actin.left_end[j], actin.right_end[j], box);
         if (distance<crosslinker_length){
             crosslink = true;
         }
     }
     if (!crosslink){
+        if (was_strong){
+            cb_breakage_events.insert(cb_breakage_events.end(),
+                                      {static_cast<double>(i), static_cast<double>(j),
+                                       static_cast<double>(current_step), distance, cos_angle});
+        }
         return 0; // return -1 for non-catch bond
     }
-    double cos_angle = actin.direction[i].dot(actin.direction[j]);
     bool catch_bond =(actin_basic_tension[i]>EPS && actin_basic_tension[j]>EPS);
     if (directional){
         catch_bond = (catch_bond && cos_angle<0);
     }
     if (!catch_bond){
+        if (was_strong){
+            cb_breakage_events.insert(cb_breakage_events.end(),
+                                      {static_cast<double>(i), static_cast<double>(j),
+                                       static_cast<double>(current_step), distance, cos_angle});
+        }
         return 1;
     }
     auto& myosin_indices_i = myosinIndicesPerActin.getConnections(i);
     auto& myosin_indices_j = myosinIndicesPerActin.getConnections(j);
     if (myosin_indices_i.empty() || myosin_indices_j.empty()){
+        if (was_strong){
+            cb_breakage_events.insert(cb_breakage_events.end(),
+                                      {static_cast<double>(i), static_cast<double>(j),
+                                       static_cast<double>(current_step), distance, cos_angle});
+        }
         return 1;
     }
     for (int mi : myosin_indices_i){
@@ -769,6 +791,11 @@ int Sarcomere::determine_cb_status(int& i, int& j){
                 return 2;
             }
         }
+    }
+    if (was_strong){
+        cb_breakage_events.insert(cb_breakage_events.end(),
+                                  {static_cast<double>(i), static_cast<double>(j),
+                                   static_cast<double>(current_step), distance, cos_angle});
     }
     return 1;
 }
@@ -1041,6 +1068,16 @@ void Sarcomere::save_state(){
     std::vector<double> flatActinMyosinBonds = std::get<2>(bondData);
     append_to_file(filename, actin, myosin, flatActinBonds,
                    flatMyosinBonds, flatActinMyosinBonds, max_myosin_bonds);
+
+    // Flush any recorded catch-bond breakage events to the HDF5 file
+    if (!cb_breakage_events.empty()) {
+        H5::H5File file(filename, H5F_ACC_RDWR);
+        H5::Group group_cb(file.openGroup("/catch_bond"));
+        hsize_t n_events = cb_breakage_events.size() / 5;
+        append_to_dataset(group_cb, "breakage", cb_breakage_events,
+                           {n_events, static_cast<hsize_t>(5)});
+        cb_breakage_events.clear();
+    }
 }
 
 void Sarcomere::load_state(int& n_frames){


### PR DESCRIPTION
## Summary
- Track global timestep and catch-bond breakage metrics in `Sarcomere`
- Store breakage events to an HDF5 dataset for later analysis
- Add Python utility to plot actin pair distance and angle at breakage

## Testing
- `cmake ..`
- `make -j4`
- `python -m py_compile analysis/analyze_catch_bonds.py`


------
https://chatgpt.com/codex/tasks/task_e_68af92444bac8333aa43137f0f228e9a