### PR TITLE
Track previous actin-actin bond status for break detection

### DIFF
--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -35,7 +35,7 @@ public:
     utils::MoleculeConnection actinIndicesPerActin;
 
     std::vector<std::vector<int>> actin_actin_bonds, actin_actin_bonds_prev;
-    std::vector<std::vector<int>> actin_actin_status;
+    std::vector<std::vector<int>> actin_actin_status, actin_actin_status_prev;
     // Track lifetime (in steps) for each actin–actin catch bond
     std::vector<std::vector<int>> actin_actin_lifetime, actin_actin_lifetime_prev;
     // Track actin–myosin bonds

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -14,6 +14,7 @@ Sarcomere::Sarcomere(int& n_actins, int& n_myosins, vector box0, double& actin_l
               neighbor_list(0.0, box0, 0.0),
                 actin_actin_bonds(n_actins, std::vector<int>(n_actins, 0)),
                 actin_actin_status(n_actins, std::vector<int>(n_actins, 0)),
+                actin_actin_status_prev(n_actins, std::vector<int>(n_actins, 0)),
                 actin_actin_lifetime(n_actins, std::vector<int>(n_actins, 0)),
                 am_bonds(n_actins, std::vector<int>(n_myosins, 0)),
                 actin_forces_temp(omp_get_max_threads(), std::vector<vec>(n_actins, {0, 0, 0})),
@@ -399,6 +400,7 @@ void Sarcomere::_set_to_zero() {
         myosinIndicesPerActin.deleteAllConnections(i);
         for (int j = 0; j < actin.n; j++){
             actin_actin_bonds_prev[i][j] = actin_actin_bonds[i][j];
+            actin_actin_status_prev[i][j] = actin_actin_status[i][j];
             actin_actin_bonds[i][j] = 0;
             actin_actin_status[i][j] = 0;
             actin_actin_lifetime_prev[i][j] = actin_actin_lifetime[i][j];
@@ -746,7 +748,7 @@ int Sarcomere::determine_cb_status(int& i, int& j){
         actin.left_end[i], actin.right_end[i], actin.left_end[j], actin.right_end[j], box);
     double cos_angle = actin.direction[i].dot(actin.direction[j]);
 
-    bool was_strong = (actin_actin_status[i][j] == 2);
+    bool was_strong = (actin_actin_status_prev[i][j] == 2);
     bool crosslink = false;
     if (actin_crosslink_ratio[i] > EPS && actin_crosslink_ratio[j] > EPS || ! directional){
         if (distance<crosslinker_length){


### PR DESCRIPTION
## Summary
- store prior actin–actin bond state in new `actin_actin_status_prev`
- copy statuses before reset and reference them when computing catch bond state

## Testing
- `g++ -std=c++17 cpp/tests.cpp cpp/src/sarcomere.cpp cpp/src/geometry.cpp cpp/src/interaction.cpp cpp/src/utils.cpp cpp/src/neighborlist.cpp cpp/src/h5_utils.cpp cpp/src/components.cpp cpp/src/langevin.cpp -Icpp/include -Icpp/autodiff -I/usr/include/eigen3 -I/usr/include/hdf5/serial -lgsl -lgslcblas -lhdf5 -lhdf5_cpp -lhdf5_hl -fopenmp -lgtest -lgtest_main -lpthread -o tests` *(fails: no matching function for call to 'Sarcomere::Sarcomere')*


------
https://chatgpt.com/codex/tasks/task_e_68af9bd5556c83339b268d3dd37af95e