### PR TITLE
Log context for catch-bond breakage events

### DIFF
--- a/analysis/analyze_catch_bonds.py
+++ b/analysis/analyze_catch_bonds.py
@@ -34,7 +34,8 @@ def compute_pair_fload(
 
 
 def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis") -> None:
-    """Read recorded catch-bond breakage events and plot distance and angle vs time."""
+    """Read recorded catch-bond breakage events and plot distance, angle,
+    tension and myosin-attachment metrics vs time."""
     with h5py.File(h5file, "r") as fh:
         if "/catch_bond/breakage" not in fh:
             print("No catch-bond breakage data found in file")
@@ -49,6 +50,12 @@ def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis")
     times = steps * dt
     distances = data[:, 3]
     angles = np.degrees(np.arccos(np.clip(data[:, 4], -1.0, 1.0)))
+    tension_i = data[:, 5]
+    tension_j = data[:, 6]
+    min_tension = np.minimum(tension_i, tension_j)
+    count_i = data[:, 7]
+    count_j = data[:, 8]
+    total_myo = count_i + count_j
 
     plt.figure()
     plt.scatter(times, distances, s=10, alpha=0.7)
@@ -65,6 +72,27 @@ def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis")
     plt.tight_layout()
     plt.savefig(f"{prefix}_cb_break_angle_vs_time.png", dpi=300)
     plt.close()
+
+    plt.figure()
+    plt.scatter(times, min_tension, s=10, alpha=0.7)
+    plt.xlabel("Time")
+    plt.ylabel("Minimum tension at break")
+    plt.tight_layout()
+    plt.savefig(f"{prefix}_cb_break_min_tension_vs_time.png", dpi=300)
+    plt.close()
+
+    plt.figure()
+    plt.scatter(times, total_myo, s=10, alpha=0.7)
+    plt.xlabel("Time")
+    plt.ylabel("Total myosins attached at break")
+    plt.tight_layout()
+    plt.savefig(f"{prefix}_cb_break_total_myosins_vs_time.png", dpi=300)
+    plt.close()
+
+    tensionless = np.sum(min_tension < 1e-6)
+    detached = np.sum((count_i == 0) | (count_j == 0))
+    print(f"{tensionless} of {len(times)} break events occurred with near-zero tension")
+    print(f"{detached} events involved an actin with no myosin attachments")
 
 
 def analyze_catch_bonds(h5file: str, dt: float = 1.0,

--- a/cpp/src/h5_utils.cpp
+++ b/cpp/src/h5_utils.cpp
@@ -272,10 +272,13 @@ void create_file(std::string& filename, Filament& actin, Myosin& myosin,
     create_empty_dataset(file, "/actin_myo", "bonds", initialDims, maxDims, chunkDims);
 
     // Dataset to record catch-bond breakage events:
-    // columns: i, j, step, distance, cos_angle
-    initialDims = {0, 5};
-    maxDims     = {H5S_UNLIMITED, 5};
-    chunkDims   = {10, 5};
+    // columns: i, j, step, distance, cos_angle,
+    //          tension_i, tension_j, myosin_count_i, myosin_count_j,
+    //          myosin_ids_i[0:max_myosin_bonds-1], myosin_ids_j[0:max_myosin_bonds-1]
+    hsize_t event_width = 9 + 2 * max_myosin_bonds;
+    initialDims = {0, event_width};
+    maxDims     = {H5S_UNLIMITED, event_width};
+    chunkDims   = {10, event_width};
     create_empty_dataset(file, "/catch_bond", "breakage", initialDims, maxDims, chunkDims);
 }
 

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -752,6 +752,35 @@ int Sarcomere::determine_cb_status(int& i, int& j){
     if (was_strong){
         printf("Actins %d and %d were strongly crosslinked, distance: %f, cos_angle: %f\n", i, j, distance, cos_angle);
     }
+
+    auto record_break = [&](void){
+        auto& myosin_indices_i = myosinIndicesPerActin.getConnections(i);
+        auto& myosin_indices_j = myosinIndicesPerActin.getConnections(j);
+        double tension_i = actin_basic_tension[i];
+        double tension_j = actin_basic_tension[j];
+        printf("Catch bond between actins %d and %d broke. distance: %f, cos_angle: %f, tensions: %f, %f, myosins_i(%zu):",
+               i, j, distance, cos_angle, tension_i, tension_j, myosin_indices_i.size());
+        for (int mi : myosin_indices_i) { printf(" %d", mi); }
+        printf("; myosins_j(%zu):", myosin_indices_j.size());
+        for (int mj : myosin_indices_j) { printf(" %d", mj); }
+        printf("\n");
+        cb_breakage_events.insert(cb_breakage_events.end(),
+                                  {static_cast<double>(i), static_cast<double>(j),
+                                   static_cast<double>(current_step), distance, cos_angle,
+                                   tension_i, tension_j,
+                                   static_cast<double>(myosin_indices_i.size()),
+                                   static_cast<double>(myosin_indices_j.size())});
+        for (int k = 0; k < max_myosin_bonds; ++k) {
+            cb_breakage_events.push_back(
+                k < static_cast<int>(myosin_indices_i.size()) ?
+                    static_cast<double>(myosin_indices_i[k]) : -1.0);
+        }
+        for (int k = 0; k < max_myosin_bonds; ++k) {
+            cb_breakage_events.push_back(
+                k < static_cast<int>(myosin_indices_j.size()) ?
+                    static_cast<double>(myosin_indices_j[k]) : -1.0);
+        }
+    };
     bool crosslink = false;
     if (actin_crosslink_ratio[i] > EPS && actin_crosslink_ratio[j] > EPS || ! directional){
         if (distance<crosslinker_length){
@@ -761,9 +790,7 @@ int Sarcomere::determine_cb_status(int& i, int& j){
     if (!crosslink){
         if (was_strong){
             printf("Actins %d and %d no longer crosslinked, distance: %f, cos_angle: %f\n", i, j, distance, cos_angle);
-            cb_breakage_events.insert(cb_breakage_events.end(),
-                                      {static_cast<double>(i), static_cast<double>(j),
-                                       static_cast<double>(current_step), distance, cos_angle});
+            record_break();
         }
         return 0; // return -1 for non-catch bond
     }
@@ -773,9 +800,7 @@ int Sarcomere::determine_cb_status(int& i, int& j){
     }
     if (!catch_bond){
         if (was_strong){
-            cb_breakage_events.insert(cb_breakage_events.end(),
-                                      {static_cast<double>(i), static_cast<double>(j),
-                                       static_cast<double>(current_step), distance, cos_angle});
+            record_break();
         }
         return 1;
     }
@@ -783,9 +808,7 @@ int Sarcomere::determine_cb_status(int& i, int& j){
     auto& myosin_indices_j = myosinIndicesPerActin.getConnections(j);
     if (myosin_indices_i.empty() || myosin_indices_j.empty()){
         if (was_strong){
-            cb_breakage_events.insert(cb_breakage_events.end(),
-                                      {static_cast<double>(i), static_cast<double>(j),
-                                       static_cast<double>(current_step), distance, cos_angle});
+            record_break();
         }
         return 1;
     }
@@ -799,9 +822,7 @@ int Sarcomere::determine_cb_status(int& i, int& j){
         }
     }
     if (was_strong){
-        cb_breakage_events.insert(cb_breakage_events.end(),
-                                  {static_cast<double>(i), static_cast<double>(j),
-                                   static_cast<double>(current_step), distance, cos_angle});
+        record_break();
     }
     return 1;
 }
@@ -1079,9 +1100,10 @@ void Sarcomere::save_state(){
     if (!cb_breakage_events.empty()) {
         H5::H5File file(filename, H5F_ACC_RDWR);
         H5::Group group_cb(file.openGroup("/catch_bond"));
-        hsize_t n_events = cb_breakage_events.size() / 5;
+        hsize_t event_width = 9 + 2 * max_myosin_bonds;
+        hsize_t n_events = cb_breakage_events.size() / event_width;
         append_to_dataset(group_cb, "breakage", cb_breakage_events,
-                           {n_events, static_cast<hsize_t>(5)});
+                           {n_events, event_width});
         cb_breakage_events.clear();
     }
 }


### PR DESCRIPTION
## Summary
- Record catch-bond break details with actin tensions, myosin connection counts, and IDs
- Store extended breakage context in HDF5 output and update analysis to correlate breaks with tension loss or detachment

## Testing
- `cmake ..` *(fails: missing libs)*
- `cmake --build .`
- `python -m py_compile analysis/analyze_catch_bonds.py`


------
https://chatgpt.com/codex/tasks/task_e_68b21455bc408333981d5fc1d8626261