### PR TITLE
Log limit-driven actin bond removals and analysis table

### DIFF
--- a/analysis/analyze_catch_bonds.py
+++ b/analysis/analyze_catch_bonds.py
@@ -95,6 +95,25 @@ def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis")
     print(f"{detached} events involved an actin with no myosin attachments")
 
 
+def summarize_limit_removals(h5file: str) -> None:
+    """Print a table summarizing limit-enforced catch-bond removals."""
+    with h5py.File(h5file, "r") as fh:
+        if "/catch_bond/limit_removal" not in fh:
+            print("No limit-removal data found in file")
+            return
+        data = np.asarray(fh["/catch_bond/limit_removal"])
+
+    if data.size == 0:
+        print("No limit-removal events recorded")
+        return
+
+    header = f"{'step':>10} {'i':>5} {'j':>5} {'bonds_i':>8} {'bonds_j':>8}"
+    print("Limit-enforced removals")
+    print(header)
+    for row in data:
+        print(f"{int(row[2]):>10} {int(row[0]):>5} {int(row[1]):>5} {int(row[3]):>8} {int(row[4]):>8}")
+
+
 def analyze_catch_bonds(h5file: str, dt: float = 1.0,
                         prefix: str = "analysis",
                         start_frame: int = 0) -> None:
@@ -395,6 +414,7 @@ def main() -> None:
                         prefix=args.prefix,
                         start_frame=args.start_frame)
     plot_breakage_events(args.h5file, dt=args.dt, prefix=args.prefix)
+    summarize_limit_removals(args.h5file)
 
 if __name__ == "__main__":
     main()

--- a/cpp/include/sarcomere.h
+++ b/cpp/include/sarcomere.h
@@ -73,6 +73,10 @@ public:
     // Flat buffer storing (i, j, step, distance, cos_angle) for each breakage
     std::vector<double> cb_breakage_events;
 
+    // Flat buffer storing (i, j, step, bond_count_i, bond_count_j) for
+    // removals triggered by the max_strong_actin_bonds limit
+    std::vector<double> cb_limit_events;
+
     // Constructors & Destructor
     Sarcomere();
     Sarcomere(int& n_actins, int& n_myosins, vector box0, double& actin_length, double& myosin_length,

--- a/cpp/src/h5_utils.cpp
+++ b/cpp/src/h5_utils.cpp
@@ -280,6 +280,14 @@ void create_file(std::string& filename, Filament& actin, Myosin& myosin,
     maxDims     = {H5S_UNLIMITED, event_width};
     chunkDims   = {10, event_width};
     create_empty_dataset(file, "/catch_bond", "breakage", initialDims, maxDims, chunkDims);
+
+    // Dataset to record removals triggered by max_strong_actin_bonds
+    // columns: i, j, step, bond_count_i, bond_count_j
+    hsize_t limit_width = 5;
+    initialDims = {0, limit_width};
+    maxDims     = {H5S_UNLIMITED, limit_width};
+    chunkDims   = {10, limit_width};
+    create_empty_dataset(file, "/catch_bond", "limit_removal", initialDims, maxDims, chunkDims);
 }
 
 

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -517,6 +517,14 @@ void Sarcomere::_enforce_actin_cb_limit() {
                 if (actin_actin_bonds[j][k2] == 1)
                     actin.cb_status[j] = std::max(actin.cb_status[j], actin_actin_status[j][k2]);
             }
+            // Log the enforced removal with timestamp and current bond counts
+            printf("Limit removal of actins %d-%d at step %zu (bonds: %d %d)\n",
+                   i, j, current_step, actin_n_bonds[i], actin_n_bonds[j]);
+            cb_limit_events.insert(cb_limit_events.end(),
+                                   {static_cast<double>(i), static_cast<double>(j),
+                                    static_cast<double>(current_step),
+                                    static_cast<double>(actin_n_bonds[i]),
+                                    static_cast<double>(actin_n_bonds[j])});
         }
     }
 }
@@ -1096,15 +1104,26 @@ void Sarcomere::save_state(){
     append_to_file(filename, actin, myosin, flatActinBonds,
                    flatMyosinBonds, flatActinMyosinBonds, max_myosin_bonds);
 
-    // Flush any recorded catch-bond breakage events to the HDF5 file
-    if (!cb_breakage_events.empty()) {
+    // Flush any recorded catch-bond events to the HDF5 file
+    if (!cb_breakage_events.empty() || !cb_limit_events.empty()) {
         H5::H5File file(filename, H5F_ACC_RDWR);
         H5::Group group_cb(file.openGroup("/catch_bond"));
-        hsize_t event_width = 9 + 2 * max_myosin_bonds;
-        hsize_t n_events = cb_breakage_events.size() / event_width;
-        append_to_dataset(group_cb, "breakage", cb_breakage_events,
-                           {n_events, event_width});
-        cb_breakage_events.clear();
+
+        if (!cb_breakage_events.empty()) {
+            hsize_t event_width = 9 + 2 * max_myosin_bonds;
+            hsize_t n_events = cb_breakage_events.size() / event_width;
+            append_to_dataset(group_cb, "breakage", cb_breakage_events,
+                               {n_events, event_width});
+            cb_breakage_events.clear();
+        }
+
+        if (!cb_limit_events.empty()) {
+            hsize_t limit_width = 5;
+            hsize_t n_limit = cb_limit_events.size() / limit_width;
+            append_to_dataset(group_cb, "limit_removal", cb_limit_events,
+                               {n_limit, limit_width});
+            cb_limit_events.clear();
+        }
     }
 }
 

--- a/cpp/src/sarcomere_2d.cpp
+++ b/cpp/src/sarcomere_2d.cpp
@@ -554,6 +554,14 @@ void Sarcomere::_enforce_actin_cb_limit() {
             actin_n_bonds[j] -= 1;
             actin_strong_cb_count[i] -= 1;
             actin_strong_cb_count[j] -= 1;
+            // Log the enforced removal with timestamp and current bond counts
+            printf("Limit removal of actins %d-%d at step %zu (bonds: %d %d)\n",
+                   i, j, current_step, actin_n_bonds[i], actin_n_bonds[j]);
+            cb_limit_events.insert(cb_limit_events.end(),
+                                   {static_cast<double>(i), static_cast<double>(j),
+                                    static_cast<double>(current_step),
+                                    static_cast<double>(actin_n_bonds[i]),
+                                    static_cast<double>(actin_n_bonds[j])});
         }
     }
 }


### PR DESCRIPTION
## Summary
- record actin pair removals when exceeding `max_strong_actin_bonds` with timestamp and bond counts
- flush limit-removal events to HDF5 and summarize via new analysis function

## Testing
- `python -m py_compile analysis/analyze_catch_bonds.py`
- `cmake ..`
- `make -j2`
- `g++ -std=c++17 ../tests.cpp -I../include -I../autodiff -I/usr/include/eigen3 -I/usr/include/hdf5/serial -fopenmp libmy_library.a -lgtest -lgtest_main -lgsl -lgslcblas -lhdf5_cpp -lhdf5 -lpthread -o tests` *(fails: no matching function for call to ‘Sarcomere::Sarcomere’)*

------
https://chatgpt.com/codex/tasks/task_e_68b22ffe541c8333aa726d8a4e7cafc3