### PR TITLE
Plot actin speed before catch-bond breakage

### DIFF
--- a/analysis/analyze_catch_bonds.py
+++ b/analysis/analyze_catch_bonds.py
@@ -41,6 +41,21 @@ def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis")
             print("No catch-bond breakage data found in file")
             return
         data = np.asarray(fh["/catch_bond/breakage"])
+        vel_ds = fh["/actin/velocity"] if "/actin/velocity" in fh else None
+
+        speeds: list[float] = []
+        if vel_ds is not None and data.size:
+            for row in data:
+                step_idx = int(row[2])
+                i = int(row[0])
+                j = int(row[1])
+                frame_vel = vel_ds[min(step_idx, vel_ds.shape[0] - 1)]
+                speeds.extend(
+                    [
+                        float(np.linalg.norm(frame_vel[i])),
+                        float(np.linalg.norm(frame_vel[j])),
+                    ]
+                )
 
     if data.size == 0:
         print("No catch-bond breakage events recorded")
@@ -88,6 +103,15 @@ def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis")
     plt.tight_layout()
     plt.savefig(f"{prefix}_cb_break_total_myosins_vs_time.png", dpi=300)
     plt.close()
+
+    if speeds:
+        plt.figure()
+        plt.hist(speeds, bins=50, density=True)
+        plt.xlabel("Actin speed before break")
+        plt.ylabel("Probability density")
+        plt.tight_layout()
+        plt.savefig(f"{prefix}_cb_break_actin_speed_distribution.png", dpi=300)
+        plt.close()
 
     tensionless = np.sum(min_tension < 1e-6)
     detached = np.sum((count_i == 0) | (count_j == 0))


### PR DESCRIPTION
## Summary
- compute actin velocities for each catch-bond break event
- plot histogram of actin speeds at break

## Testing
- `python -m py_compile analysis/analyze_catch_bonds.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af90057eb0833384aa1a7e9ed22cc4