### PR TITLE
Record crosslink ratios for catch-bond break events

### DIFF
--- a/analysis/analyze_catch_bonds.py
+++ b/analysis/analyze_catch_bonds.py
@@ -119,9 +119,11 @@ def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis")
     angles = np.degrees(np.arccos(np.clip(data[:, 4], -1.0, 1.0)))
     tension_i = data[:, 5]
     tension_j = data[:, 6]
+    cross_i = data[:, 7]
+    cross_j = data[:, 8]
     min_tension = np.minimum(tension_i, tension_j)
-    count_i = data[:, 7]
-    count_j = data[:, 8]
+    count_i = data[:, 9]
+    count_j = data[:, 10]
     total_myo = count_i + count_j
 
     plt.figure()
@@ -187,8 +189,10 @@ def plot_breakage_events(h5file: str, dt: float = 1.0, prefix: str = "analysis")
 
     tensionless = np.sum(min_tension < 1e-6)
     detached = np.sum((count_i == 0) | (count_j == 0))
+    cross_zero = np.sum((cross_i == 0) | (cross_j == 0))
     print(f"{tensionless} of {len(times)} break events occurred with near-zero tension")
     print(f"{detached} events involved an actin with no myosin attachments")
+    print(f"{cross_zero} events had crosslink ratio equal to zero")
 
 
 def summarize_limit_removals(h5file: str) -> None:

--- a/cpp/src/h5_utils.cpp
+++ b/cpp/src/h5_utils.cpp
@@ -273,9 +273,10 @@ void create_file(std::string& filename, Filament& actin, Myosin& myosin,
 
     // Dataset to record catch-bond breakage events:
     // columns: i, j, step, distance, cos_angle,
-    //          tension_i, tension_j, myosin_count_i, myosin_count_j,
+    //          tension_i, tension_j, crosslink_ratio_i, crosslink_ratio_j,
+    //          myosin_count_i, myosin_count_j,
     //          myosin_ids_i[0:max_myosin_bonds-1], myosin_ids_j[0:max_myosin_bonds-1]
-    hsize_t event_width = 9 + 2 * max_myosin_bonds;
+    hsize_t event_width = 11 + 2 * max_myosin_bonds;
     initialDims = {0, event_width};
     maxDims     = {H5S_UNLIMITED, event_width};
     chunkDims   = {10, event_width};

--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -787,6 +787,7 @@ int Sarcomere::determine_cb_status(int& i, int& j){
                                   {static_cast<double>(i), static_cast<double>(j),
                                    static_cast<double>(current_step), distance, cos_angle,
                                    tension_i, tension_j,
+                                   actin_crosslink_ratio[i], actin_crosslink_ratio[j],
                                    static_cast<double>(myosin_indices_i.size()),
                                    static_cast<double>(myosin_indices_j.size())});
         for (int k = 0; k < max_myosin_bonds; ++k) {
@@ -1127,7 +1128,7 @@ void Sarcomere::save_state(){
         H5::Group group_cb(file.openGroup("/catch_bond"));
 
         if (!cb_breakage_events.empty()) {
-            hsize_t event_width = 9 + 2 * max_myosin_bonds;
+            hsize_t event_width = 11 + 2 * max_myosin_bonds;
             hsize_t n_events = cb_breakage_events.size() / event_width;
             append_to_dataset(group_cb, "breakage", cb_breakage_events,
                                {n_events, event_width});


### PR DESCRIPTION
## Summary
- Store actin crosslink ratios for each catch-bond break event in the output datasets.
- Expand catch bond breakage dataset definition to include crosslink ratios.
- Report and summarize break events where crosslink ratio is zero in analyze_catch_bonds.

## Testing
- `python -m py_compile analysis/analyze_catch_bonds.py`
- `cd cpp && mkdir -p build && cd build && cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68b7692a0d7883339e49c2f2ef02797a