### PR TITLE
Use partial binding ratio for catch bond eligibility

### DIFF
--- a/cpp/src/sarcomere.cpp
+++ b/cpp/src/sarcomere.cpp
@@ -802,8 +802,10 @@ int Sarcomere::determine_cb_status(int& i, int& j){
         }
     };
     bool crosslink = false;
-    if (actin_crosslink_ratio[i] > EPS && actin_crosslink_ratio[j] > EPS || ! directional){
-        if (distance<crosslinker_length){
+    double partial_i = actin["partial_binding_ratio"][i];
+    double partial_j = actin["partial_binding_ratio"][j];
+    if ((partial_i < 1.0 - EPS && partial_j < 1.0 - EPS) || !directional) {
+        if (distance < crosslinker_length) {
             crosslink = true;
         }
     }

--- a/cpp/src/sarcomere_2d.cpp
+++ b/cpp/src/sarcomere_2d.cpp
@@ -797,10 +797,13 @@ double Sarcomere::_get_cb_strength(int& i, int& j){
     double angle = actin.theta[i] - actin.theta[j];
     double cos_angle = std::cos(angle);
     bool crosslink = false;
-    if (actin_crosslink_ratio[i]>EPS && actin_crosslink_ratio[j]>EPS || ! directional){
-        double distance = geometry::segment_segment_distance(actin.left_end[i], 
-            actin.right_end[i], actin.left_end[j], actin.right_end[j], box, pbc_mask);
-        if (distance<crosslinker_length){
+    double partial_i = actin["partial_binding_ratio"][i];
+    double partial_j = actin["partial_binding_ratio"][j];
+    if ((partial_i < 1.0 - EPS && partial_j < 1.0 - EPS) || !directional) {
+        double distance = geometry::segment_segment_distance(
+            actin.left_end[i], actin.right_end[i],
+            actin.left_end[j], actin.right_end[j], box, pbc_mask);
+        if (distance < crosslinker_length) {
             crosslink = true;
         }
     }

--- a/cpp/src/sarcomere_2d_old.cpp
+++ b/cpp/src/sarcomere_2d_old.cpp
@@ -690,10 +690,13 @@ double Sarcomere::_get_cb_strength(int& i, int& j){
     double angle = actin.theta[i] - actin.theta[j];
     double cos_angle = std::cos(angle);
     bool crosslink = false;
-    if (actin_crosslink_ratio[i]>EPS && actin_crosslink_ratio[j]>EPS || ! directional){
-        double distance = geometry::segment_segment_distance(actin.left_end[i], 
-            actin.right_end[i], actin.left_end[j], actin.right_end[j], box, pbc_mask);
-        if (distance<crosslinker_length){
+    double partial_i = actin["partial_binding_ratio"][i];
+    double partial_j = actin["partial_binding_ratio"][j];
+    if ((partial_i < 1.0 - EPS && partial_j < 1.0 - EPS) || !directional) {
+        double distance = geometry::segment_segment_distance(
+            actin.left_end[i], actin.right_end[i],
+            actin.left_end[j], actin.right_end[j], box, pbc_mask);
+        if (distance < crosslinker_length) {
             crosslink = true;
         }
     }


### PR DESCRIPTION
## Summary
- require actin's partial binding ratio to be less than one before crosslinking
- apply the same partial-binding check to 2D sarcomere variants

## Testing
- `cmake .. && make -j$(nproc)`
- `g++ -std=c++17 ../tests.cpp -I../include -I../autodiff -I/usr/include/eigen3 -I/usr/include/hdf5/serial -L. -lmy_library -lgtest -lgtest_main -lgsl -lgslcblas -lhdf5_cpp -lhdf5 -fopenmp -pthread -o tests` *(fails: no matching function for call to 'Sarcomere::Sarcomere')*


------
https://chatgpt.com/codex/tasks/task_e_68b77a5fd1b48333bd18757e9a5f9b28